### PR TITLE
feat: add linting as a pipeline step in Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,7 +34,7 @@ jobs:
       run: go vet ./...
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v9
       with:
         version: v2.11.3
 


### PR DESCRIPTION
Adds  as a new step in the GitHub Actions workflow and defines a default version in the Makefile to ensure consistent linting across environments.\n\nFixes #22