### PR TITLE
FileSensor implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cover.out
 .vscode/
 bin/
+/data/*

--- a/cmd/modelsrv/server.go
+++ b/cmd/modelsrv/server.go
@@ -1,15 +1,24 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	eventmgr "go.emeland.io/modelsrv/internal/events"
 	"go.emeland.io/modelsrv/pkg/endpoint"
+	"go.emeland.io/modelsrv/pkg/filesensor"
 	"go.emeland.io/modelsrv/pkg/model"
+	"go.uber.org/zap"
 )
 
 var serviceAddr string
+var dataDir string
 
 // serverCmd represents the server command
 var serverCmd = &cobra.Command{
@@ -18,30 +27,64 @@ var serverCmd = &cobra.Command{
 	Long:  `minimal model server instance that serves the model via REST API and provides a minimal web UI.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
+		cfg := zap.NewDevelopmentConfig()
+		cfg.DisableStacktrace = true
+		log, err := cfg.Build()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "logger: %v\n", err)
+			os.Exit(1)
+		}
+		defer log.Sync() //nolint:errcheck
+
+		logger := log.Sugar()
+
 		eventMgr, err := eventmgr.NewEventManager()
 		if err != nil {
-			fmt.Println("Error creating event manager: ", err)
+			logger.Errorw("error creating event manager", "error", err)
 			return
 		}
 
 		sink, err := eventMgr.GetSink()
 		if err != nil {
-			fmt.Println("Error creating event sink: ", err)
+			logger.Errorw("error getting event sink", "error", err)
 			return
 		}
 
 		model, err := model.NewModel(sink)
 		if err != nil {
-			fmt.Println("Error creating model: ", err)
+			logger.Errorw("error creating model", "error", err)
 			return
 		}
 
-		fmt.Println("Starting server...")
+		dataPath := dataDir
+		if !filepath.IsAbs(dataPath) {
+			if abs, err := filepath.Abs(dataPath); err == nil {
+				dataPath = abs
+			}
+		}
+		logger.Infow("starting modelsrv",
+			"listen", serviceAddr,
+			"dataDir", dataPath,
+		)
+		logger.Infof("REST API: http://%s/api", serviceAddr)
+		logger.Infof("Swagger UI: http://%s/swagger/", serviceAddr)
+		logger.Info("file sensor: watching for YAML in data directory")
+
+		filesensor.Start(context.Background(), dataPath, model, logger)
+
 		if err := endpoint.StarWebListener(model, eventMgr, serviceAddr); err != nil {
-			fmt.Println("Error starting web listener: ", err)
+			logger.Errorw("error starting web listener", "error", err)
 			return
 		}
-		fmt.Println("Server started successfully")
+
+		logger.Info("server is running (Ctrl+C to stop)")
+
+		sigCh := make(chan os.Signal, 1)
+		notifyShutdownSignals(sigCh)
+		sig := <-sigCh
+		logger.Infow("shutdown signal received", "signal", sig.String())
+		endpoint.StopWebListener()
+		logger.Info("goodbye")
 	},
 }
 
@@ -49,4 +92,13 @@ func init() {
 	rootCmd.AddCommand(serverCmd)
 
 	serverCmd.Flags().StringVarP(&serviceAddr, "service-addr", "a", ":8080", "The address the service listens on")
+	serverCmd.Flags().StringVar(&dataDir, "data-dir", "data", "Directory to watch for YAML model definitions (.yaml/.yml); relative paths are resolved from the process working directory")
+}
+
+func notifyShutdownSignals(ch chan os.Signal) {
+	if runtime.GOOS == "windows" {
+		signal.Notify(ch, os.Interrupt)
+		return
+	}
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.10
 
 require (
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
@@ -17,13 +18,13 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.27.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
@@ -53,5 +54,4 @@ require (
 	golang.org/x/tools v0.36.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/endpoint/web_endpoint.go
+++ b/pkg/endpoint/web_endpoint.go
@@ -53,6 +53,9 @@ func StarWebListener(backend model.Model, eventMgr events.EventManager, addr str
 }
 
 func StopWebListener() {
+	if webServer == nil {
+		return
+	}
 	if err := webServer.Shutdown(context.Background()); err != nil {
 		setupLog.Error("Error shutting down web server: ", err)
 	}

--- a/pkg/filesensor/apply.go
+++ b/pkg/filesensor/apply.go
@@ -1,0 +1,359 @@
+package filesensor
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"go.emeland.io/modelsrv/pkg/events"
+	"go.emeland.io/modelsrv/pkg/model"
+)
+
+// AnnotationContextTypeID is the annotation key used to store a Context's context-type UUID when the domain type has no dedicated field.
+const AnnotationContextTypeID = "contextTypeId"
+
+func displayName(spec map[string]any) (string, error) {
+	if s, ok := stringField(spec, "displayName"); ok && strings.TrimSpace(s) != "" {
+		return strings.TrimSpace(s), nil
+	}
+	if s, ok := stringField(spec, "name"); ok && strings.TrimSpace(s) != "" {
+		return strings.TrimSpace(s), nil
+	}
+	return "", fmt.Errorf("spec must include non-empty displayName or name")
+}
+
+func stringField(spec map[string]any, key string) (string, bool) {
+	v, ok := spec[key]
+	if !ok || v == nil {
+		return "", false
+	}
+	switch t := v.(type) {
+	case string:
+		return t, true
+	default:
+		return fmt.Sprint(t), true
+	}
+}
+
+func parseUUIDField(spec map[string]any, key string) (uuid.UUID, error) {
+	s, ok := stringField(spec, key)
+	if !ok || strings.TrimSpace(s) == "" {
+		return uuid.Nil, fmt.Errorf("missing or empty %q", key)
+	}
+	id, err := uuid.Parse(strings.TrimSpace(s))
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("%q: %w", key, err)
+	}
+	if id == uuid.Nil {
+		return uuid.Nil, fmt.Errorf("%q must not be nil UUID", key)
+	}
+	return id, nil
+}
+
+func optionalUUIDRef(spec map[string]any, key string) (uuid.UUID, bool, error) {
+	v, ok := spec[key]
+	if !ok || v == nil {
+		return uuid.Nil, false, nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return uuid.Nil, false, fmt.Errorf("%q must be a string UUID or null", key)
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return uuid.Nil, false, nil
+	}
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.Nil, false, fmt.Errorf("%q: %w", key, err)
+	}
+	if id == uuid.Nil {
+		return uuid.Nil, true, fmt.Errorf("%q must not be nil UUID", key)
+	}
+	return id, true, nil
+}
+
+func optionalFirstUUIDRef(spec map[string]any, keys ...string) (uuid.UUID, bool, error) {
+	for _, k := range keys {
+		id, has, err := optionalUUIDRef(spec, k)
+		if err != nil {
+			return uuid.Nil, false, err
+		}
+		if has {
+			return id, true, nil
+		}
+	}
+	return uuid.Nil, false, nil
+}
+
+func applyAnnotations(ann model.Annotations, spec map[string]any) error {
+	raw, ok := spec["annotations"]
+	if !ok || raw == nil {
+		return nil
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("annotations must be a map")
+	}
+	for k, v := range m {
+		if v == nil {
+			continue
+		}
+		val, ok := v.(string)
+		if !ok {
+			val = fmt.Sprint(v)
+		}
+		ann.Add(k, val)
+	}
+	return nil
+}
+
+func parseVersionSpec(v any) (model.Version, error) {
+	var out model.Version
+	if v == nil {
+		return out, nil
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		return out, fmt.Errorf("version must be a map")
+	}
+	if s, ok := stringField(m, "version"); ok {
+		out.Version = s
+	}
+	if t, err := parseOptionalTime(m, "availableFrom"); err != nil {
+		return out, err
+	} else {
+		out.AvailableFrom = t
+	}
+	if t, err := parseOptionalTime(m, "deprecatedFrom"); err != nil {
+		return out, err
+	} else {
+		out.DeprecatedFrom = t
+	}
+	if t, err := parseOptionalTime(m, "terminatedFrom"); err != nil {
+		return out, err
+	} else {
+		out.TerminatedFrom = t
+	}
+	if out.TerminatedFrom == nil {
+		if t, err := parseOptionalTime(m, "retiredFrom"); err != nil {
+			return out, err
+		} else {
+			out.TerminatedFrom = t
+		}
+	}
+	return out, nil
+}
+
+func parseOptionalTime(m map[string]any, key string) (*time.Time, error) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return nil, nil
+	}
+	switch t := v.(type) {
+	case string:
+		pt, err := time.Parse(time.RFC3339, strings.TrimSpace(t))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", key, err)
+		}
+		return &pt, nil
+	case time.Time:
+		return &t, nil
+	default:
+		return nil, fmt.Errorf("%s must be an RFC3339 string or time value", key)
+	}
+}
+
+func parseApiType(s string) (model.ApiType, error) {
+	switch strings.TrimSpace(s) {
+	case "OpenAPI":
+		return model.OpenAPI, nil
+	case "GraphQL":
+		return model.GraphQL, nil
+	case "GRPC":
+		return model.GRPC, nil
+	case "Other":
+		return model.Other, nil
+	case "Unknown":
+		return model.Unknown, nil
+	default:
+		return model.Unknown, fmt.Errorf("invalid API type %q (expected OpenAPI, GraphQL, GRPC, Other, or Unknown)", s)
+	}
+}
+
+// ApplyDocument validates and applies a single decoded [Document] to the model.
+func ApplyDocument(doc Document, m model.Model) error {
+	if !ValidVersion(doc.Version) {
+		return fmt.Errorf("unsupported version %q (expected emeland.io/...)", doc.Version)
+	}
+	if doc.Spec == nil {
+		return fmt.Errorf("spec is required")
+	}
+
+	rt := doc.Kind.ResourceType()
+	switch rt {
+	case events.ContextResource:
+		return applyContext(doc.Spec, m)
+	case events.ContextTypeResource:
+		return applyContextType(doc.Spec, m)
+	case events.NodeResource:
+		return applyNode(doc.Spec, m)
+	case events.NodeTypeResource:
+		return applyNodeType(doc.Spec, m)
+	case events.SystemResource:
+		return applySystem(doc.Spec, m)
+	case events.SystemInstanceResource:
+		return applySystemInstance(doc.Spec, m)
+	case events.APIResource:
+		return applyAPI(doc.Spec, m)
+	case events.APIInstanceResource:
+		return applyAPIInstance(doc.Spec, m)
+	case events.ComponentResource:
+		return applyComponent(doc.Spec, m)
+	case events.ComponentInstanceResource:
+		return applyComponentInstance(doc.Spec, m)
+	case events.FindingResource:
+		return applyFinding(doc.Spec, m)
+	case events.FindingTypeResource:
+		return applyFindingType(doc.Spec, m)
+	case events.UnknownResourceType:
+		return fmt.Errorf("kind is required")
+	default:
+		return fmt.Errorf("unsupported kind %s", rt)
+	}
+}
+
+func applyContext(spec map[string]any, m model.Model) error {
+	id, err := parseUUIDField(spec, "contextId")
+	if err != nil {
+		return err
+	}
+	name, err := displayName(spec)
+	if err != nil {
+		return err
+	}
+
+	ctx := model.NewContext(m.GetSink(), id)
+	ctx.SetDisplayName(name)
+	if desc, ok := stringField(spec, "description"); ok {
+		ctx.SetDescription(desc)
+	}
+
+	if parentID, hasParent, err := optionalUUIDRef(spec, "parent"); err != nil {
+		return err
+	} else if hasParent {
+		ctx.SetParentById(parentID)
+	}
+
+	if typeID, hasType, err := optionalUUIDRef(spec, "type"); err != nil {
+		return err
+	} else if hasType {
+		ctx.GetAnnotations().Add(AnnotationContextTypeID, typeID.String())
+	}
+
+	if err := applyAnnotations(ctx.GetAnnotations(), spec); err != nil {
+		return err
+	}
+
+	return m.AddContext(ctx)
+}
+
+func applySystem(spec map[string]any, m model.Model) error {
+	id, err := parseUUIDField(spec, "systemId")
+	if err != nil {
+		return err
+	}
+	name, err := displayName(spec)
+	if err != nil {
+		return err
+	}
+
+	sys := model.NewSystem(m.GetSink(), id)
+	sys.SetDisplayName(name)
+	if desc, ok := stringField(spec, "description"); ok {
+		sys.SetDescription(desc)
+	}
+	if v, ok := spec["abstract"]; ok {
+		b, ok := v.(bool)
+		if !ok {
+			return fmt.Errorf("abstract must be a boolean")
+		}
+		sys.SetAbstract(b)
+	}
+	if ver, err := parseVersionSpec(spec["version"]); err != nil {
+		return err
+	} else {
+		sys.SetVersion(ver)
+	}
+
+	if parentID, hasParent, err := optionalUUIDRef(spec, "parent"); err != nil {
+		return err
+	} else if hasParent {
+		sys.SetParent(&model.SystemRef{SystemId: parentID})
+	}
+
+	if err := applyAnnotations(sys.GetAnnotations(), spec); err != nil {
+		return err
+	}
+
+	return m.AddSystem(sys)
+}
+
+func applyAPI(spec map[string]any, m model.Model) error {
+	id, err := parseUUIDField(spec, "apiId")
+	if err != nil {
+		return err
+	}
+	name, err := displayName(spec)
+	if err != nil {
+		return err
+	}
+
+	var systemID uuid.UUID
+	if s, ok := stringField(spec, "system"); ok && strings.TrimSpace(s) != "" {
+		systemID, err = uuid.Parse(strings.TrimSpace(s))
+		if err != nil {
+			return fmt.Errorf("system: %w", err)
+		}
+	} else if s, ok := stringField(spec, "systemId"); ok && strings.TrimSpace(s) != "" {
+		systemID, err = uuid.Parse(strings.TrimSpace(s))
+		if err != nil {
+			return fmt.Errorf("systemId: %w", err)
+		}
+	} else {
+		return fmt.Errorf("spec must include system or systemId UUID")
+	}
+	if systemID == uuid.Nil {
+		return fmt.Errorf("system UUID must not be nil")
+	}
+
+	typeStr := "OpenAPI"
+	if s, ok := stringField(spec, "type"); ok && strings.TrimSpace(s) != "" {
+		typeStr = strings.TrimSpace(s)
+	}
+	apiType, err := parseApiType(typeStr)
+	if err != nil {
+		return err
+	}
+
+	api := model.NewAPI(m, id)
+	api.SetDisplayName(name)
+	if desc, ok := stringField(spec, "description"); ok {
+		api.SetDescription(desc)
+	}
+	api.SetType(apiType)
+	if ver, err := parseVersionSpec(spec["version"]); err != nil {
+		return err
+	} else {
+		api.SetVersion(ver)
+	}
+	api.SetSystem(&model.SystemRef{SystemId: systemID})
+
+	if err := applyAnnotations(api.GetAnnotations(), spec); err != nil {
+		return err
+	}
+
+	return m.AddApi(api)
+}

--- a/pkg/filesensor/apply_resources.go
+++ b/pkg/filesensor/apply_resources.go
@@ -1,0 +1,342 @@
+package filesensor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"go.emeland.io/modelsrv/pkg/events"
+	"go.emeland.io/modelsrv/pkg/model"
+)
+
+func firstUUIDField(spec map[string]any, keys ...string) (uuid.UUID, error) {
+	for _, k := range keys {
+		id, err := parseUUIDField(spec, k)
+		if err == nil {
+			return id, nil
+		}
+	}
+	return uuid.Nil, fmt.Errorf("spec must include a valid UUID in one of: %s", strings.Join(keys, ", "))
+}
+
+func parseResourceTypeForRef(s string) (events.ResourceType, error) {
+	s = strings.TrimSpace(s)
+	t := events.ParseResourceType(s)
+	if t != events.UnknownResourceType {
+		return t, nil
+	}
+	switch s {
+	case "Finding":
+		return events.FindingResource, nil
+	case "FindingType":
+		return events.FindingTypeResource, nil
+	default:
+		return 0, fmt.Errorf("unknown resource type %q", s)
+	}
+}
+
+func parseResourceRefs(spec map[string]any) ([]*model.ResourceRef, error) {
+	raw, ok := spec["resources"]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("resources must be an array")
+	}
+	var out []*model.ResourceRef
+	for i, item := range arr {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("resources[%d] must be an object", i)
+		}
+		id, err := parseUUIDField(m, "resourceId")
+		if err != nil {
+			return nil, fmt.Errorf("resources[%d]: %w", i, err)
+		}
+		rtStr, ok := stringField(m, "resourceType")
+		if !ok {
+			return nil, fmt.Errorf("resources[%d]: resourceType is required", i)
+		}
+		rt, err := parseResourceTypeForRef(rtStr)
+		if err != nil {
+			return nil, fmt.Errorf("resources[%d]: %w", i, err)
+		}
+		out = append(out, &model.ResourceRef{ResourceId: id, ResourceType: rt})
+	}
+	return out, nil
+}
+
+func parseApiRefSlice(spec map[string]any, key string) ([]model.ApiRef, error) {
+	raw, ok := spec[key]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array", key)
+	}
+	var out []model.ApiRef
+	for i, item := range arr {
+		switch t := item.(type) {
+		case string:
+			id, err := uuid.Parse(strings.TrimSpace(t))
+			if err != nil {
+				return nil, fmt.Errorf("%s[%d]: %w", key, i, err)
+			}
+			if id == uuid.Nil {
+				return nil, fmt.Errorf("%s[%d]: UUID must not be nil", key, i)
+			}
+			out = append(out, model.ApiRef{ApiID: id})
+		case map[string]any:
+			id, err := parseUUIDField(t, "apiId")
+			if err != nil {
+				return nil, fmt.Errorf("%s[%d]: %w", key, i, err)
+			}
+			out = append(out, model.ApiRef{ApiID: id})
+		default:
+			return nil, fmt.Errorf("%s[%d]: must be a UUID string or object with apiId", key, i)
+		}
+	}
+	return out, nil
+}
+
+func findingTitle(spec map[string]any) (string, error) {
+	if s, ok := stringField(spec, "summary"); ok && strings.TrimSpace(s) != "" {
+		return strings.TrimSpace(s), nil
+	}
+	return displayName(spec)
+}
+
+func applyContextType(spec map[string]any, m model.Model) error {
+	id, err := parseUUIDField(spec, "contextTypeId")
+	if err != nil {
+		return err
+	}
+	name, err := displayName(spec)
+	if err != nil {
+		return err
+	}
+	ct := model.NewContextType(m.GetSink(), id)
+	ct.SetDisplayName(name)
+	if desc, ok := stringField(spec, "description"); ok {
+		ct.SetDescription(desc)
+	}
+	if err := applyAnnotations(ct.GetAnnotations(), spec); err != nil {
+		return err
+	}
+	return m.AddContextType(ct)
+}
+
+func applyNodeType(spec map[string]any, m model.Model) error {
+	id, err := parseUUIDField(spec, "nodeTypeId")
+	if err != nil {
+		return err
+	}
+	name, err := displayName(spec)
+	if err != nil {
+		return err
+	}
+	nt := model.NewNodeType(m.GetSink(), id)
+	nt.SetDisplayName(name)
+	if desc, ok := stringField(spec, "description"); ok {
+		nt.SetDescription(desc)
+	}
+	if err := applyAnnotations(nt.GetAnnotations(), spec); err != nil {
+		return err
+	}
+	return m.AddNodeType(nt)
+}
+
+func applyNode(spec map[string]any, m model.Model) error {
+	id, err := parseUUIDField(spec, "nodeId")
+	if err != nil {
+		return err
+	}
+	name, err := displayName(spec)
+	if err != nil {
+		return err
+	}
+	n := model.NewNode(m.GetSink(), id)
+	n.SetDisplayName(name)
+	if desc, ok := stringField(spec, "description"); ok {
+		n.SetDescription(desc)
+	}
+	if typeID, has, err := optionalUUIDRef(spec, "nodeTypeId"); err != nil {
+		return err
+	} else if has {
+		n.SetTypeRef(&model.NodeTypeRef{NodeTypeId: typeID})
+	}
+	if err := applyAnnotations(n.GetAnnotations(), spec); err != nil {
+		return err
+	}
+	return m.AddNode(n)
+}
+
+func applySystemInstance(spec map[string]any, m model.Model) error {
+	id, err := firstUUIDField(spec, "instanceId", "systemInstanceId")
+	if err != nil {
+		return err
+	}
+	name, err := displayName(spec)
+	if err != nil {
+		return err
+	}
+	sid, err := firstUUIDField(spec, "system", "systemId")
+	if err != nil {
+		return err
+	}
+	si := model.NewSystemInstance(m, id)
+	si.SetDisplayName(name)
+	si.SetSystemRef(&model.SystemRef{SystemId: sid})
+	if cid, has, err := optionalFirstUUIDRef(spec, "context", "contextId"); err != nil {
+		return err
+	} else if has {
+		si.SetContextRef(&model.ContextRef{ContextId: cid})
+	}
+	if err := applyAnnotations(si.GetAnnotations(), spec); err != nil {
+		return err
+	}
+	return m.AddSystemInstance(si)
+}
+
+func applyAPIInstance(spec map[string]any, m model.Model) error {
+	id, err := firstUUIDField(spec, "instanceId", "apiInstanceId")
+	if err != nil {
+		return err
+	}
+	name, err := displayName(spec)
+	if err != nil {
+		return err
+	}
+	apiID, err := firstUUIDField(spec, "api", "apiId")
+	if err != nil {
+		return err
+	}
+	ai := model.NewApiInstance(m.GetSink(), id)
+	ai.SetDisplayName(name)
+	ai.SetApiRef(&model.ApiRef{ApiID: apiID})
+	if sid, has, err := optionalFirstUUIDRef(spec, "systemInstance", "systemInstanceId"); err != nil {
+		return err
+	} else if has {
+		ai.SetSystemInstance(&model.SystemInstanceRef{InstanceId: sid})
+	}
+	if err := applyAnnotations(ai.GetAnnotations(), spec); err != nil {
+		return err
+	}
+	return m.AddApiInstance(ai)
+}
+
+func applyComponent(spec map[string]any, m model.Model) error {
+	id, err := parseUUIDField(spec, "componentId")
+	if err != nil {
+		return err
+	}
+	name, err := displayName(spec)
+	if err != nil {
+		return err
+	}
+	sysID, err := firstUUIDField(spec, "system", "systemId")
+	if err != nil {
+		return err
+	}
+	c := model.NewComponent(m, id)
+	c.SetDisplayName(name)
+	if desc, ok := stringField(spec, "description"); ok {
+		c.SetDescription(desc)
+	}
+	if ver, err := parseVersionSpec(spec["version"]); err != nil {
+		return err
+	} else {
+		c.SetVersion(ver)
+	}
+	c.SetSystem(&model.SystemRef{SystemId: sysID})
+	if cons, err := parseApiRefSlice(spec, "consumes"); err != nil {
+		return err
+	} else if len(cons) > 0 {
+		c.SetConsumes(cons)
+	}
+	if prov, err := parseApiRefSlice(spec, "provides"); err != nil {
+		return err
+	} else if len(prov) > 0 {
+		c.SetProvides(prov)
+	}
+	if err := applyAnnotations(c.GetAnnotations(), spec); err != nil {
+		return err
+	}
+	return m.AddComponent(c)
+}
+
+func applyComponentInstance(spec map[string]any, m model.Model) error {
+	id, err := firstUUIDField(spec, "instanceId", "componentInstanceId")
+	if err != nil {
+		return err
+	}
+	name, err := displayName(spec)
+	if err != nil {
+		return err
+	}
+	compID, err := firstUUIDField(spec, "component", "componentId")
+	if err != nil {
+		return err
+	}
+	ci := model.NewComponentInstance(m, id)
+	ci.SetDisplayName(name)
+	ci.SetComponentRef(&model.ComponentRef{ComponentId: compID})
+	if sid, has, err := optionalFirstUUIDRef(spec, "systemInstance", "systemInstanceId"); err != nil {
+		return err
+	} else if has {
+		ci.SetSystemInstance(&model.SystemInstanceRef{InstanceId: sid})
+	}
+	if err := applyAnnotations(ci.GetAnnotations(), spec); err != nil {
+		return err
+	}
+	return m.AddComponentInstance(ci)
+}
+
+func applyFinding(spec map[string]any, m model.Model) error {
+	id, err := parseUUIDField(spec, "findingId")
+	if err != nil {
+		return err
+	}
+	title, err := findingTitle(spec)
+	if err != nil {
+		return err
+	}
+	f := model.NewFinding(m, id)
+	f.SetSummary(title)
+	if desc, ok := stringField(spec, "description"); ok {
+		f.SetDescription(desc)
+	}
+	refs, err := parseResourceRefs(spec)
+	if err != nil {
+		return err
+	}
+	if len(refs) > 0 {
+		f.SetResources(refs)
+	}
+	if err := applyAnnotations(f.GetAnnotations(), spec); err != nil {
+		return err
+	}
+	return m.AddFinding(f, title)
+}
+
+func applyFindingType(spec map[string]any, m model.Model) error {
+	id, err := parseUUIDField(spec, "findingTypeId")
+	if err != nil {
+		return err
+	}
+	name, err := displayName(spec)
+	if err != nil {
+		return err
+	}
+	ft := model.NewFindingType(m.GetSink(), id)
+	ft.SetDisplayName(name)
+	if desc, ok := stringField(spec, "description"); ok {
+		ft.SetDescription(desc)
+	}
+	if err := applyAnnotations(ft.GetAnnotations(), spec); err != nil {
+		return err
+	}
+	return m.AddFindingType(ft)
+}

--- a/pkg/filesensor/doc.go
+++ b/pkg/filesensor/doc.go
@@ -1,0 +1,2 @@
+// Package filesensor watches a directory for YAML model definitions and applies them to [model.Model].
+package filesensor

--- a/pkg/filesensor/filesensor_suite_test.go
+++ b/pkg/filesensor/filesensor_suite_test.go
@@ -1,0 +1,13 @@
+package filesensor_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFilesensor(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Filesensor Suite")
+}

--- a/pkg/filesensor/filesensor_test.go
+++ b/pkg/filesensor/filesensor_test.go
@@ -1,0 +1,237 @@
+package filesensor_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.emeland.io/modelsrv/pkg/events"
+	"go.emeland.io/modelsrv/pkg/filesensor"
+	"go.emeland.io/modelsrv/pkg/model"
+)
+
+var _ = Describe("DecodeDocuments", func() {
+	It("parses a multi-document YAML stream", func() {
+		data := `---
+version: emeland.io/v1
+kind: Context
+spec:
+  contextId: "22222222-2222-2222-2222-222222222222"
+  displayName: "Production"
+---
+version: emeland.io/v1alpha1
+kind: System
+spec:
+  systemId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+  displayName: "Order Service"
+`
+		docs, err := filesensor.DecodeDocuments([]byte(data))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(docs).To(HaveLen(2))
+		Expect(docs[0].Kind.ResourceType()).To(Equal(events.ContextResource))
+		Expect(docs[1].Kind.ResourceType()).To(Equal(events.SystemResource))
+		Expect(filesensor.ValidVersion(docs[0].Version)).To(BeTrue())
+		Expect(filesensor.ValidVersion(docs[1].Version)).To(BeTrue())
+	})
+
+	It("rejects a document that omits kind", func() {
+		data := `---
+version: emeland.io/v1
+spec:
+  contextId: "22222222-2222-2222-2222-222222222222"
+`
+		_, err := filesensor.DecodeDocuments([]byte(data))
+		Expect(err).To(MatchError(ContainSubstring("missing kind")))
+	})
+})
+
+var _ = Describe("ProcessFile", func() {
+	var issueExampleYAML string
+
+	It("loads test/fixtures/simple_system.yaml (System, Component, API)", func() {
+		_, file, _, ok := runtime.Caller(0)
+		Expect(ok).To(BeTrue())
+		root := filepath.Join(filepath.Dir(file), "..", "..")
+		path := filepath.Join(root, "test", "fixtures", "simple_system.yaml")
+		sink := events.NewListSink()
+		m, err := model.NewModel(sink)
+		Expect(err).NotTo(HaveOccurred())
+
+		res, err := filesensor.ProcessFile(path, m)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Applied).To(Equal(3))
+		Expect(res.Failed).To(BeEmpty())
+
+		Expect(m.GetSystemById(uuid.MustParse("b4eaa9f0-0242-4a26-9496-fa2b1a3b9330"))).NotTo(BeNil())
+		Expect(m.GetComponentById(uuid.MustParse("104e9a87-817d-486a-b834-5a70e8c4f68a"))).NotTo(BeNil())
+		Expect(m.GetApiById(uuid.MustParse("c649f2f3-462b-4a6d-8337-0d2e7403c44d"))).NotTo(BeNil())
+	})
+
+	BeforeEach(func() {
+		issueExampleYAML = `---
+version: emeland.io/v1
+kind: Context
+spec:
+  contextId: "22222222-2222-2222-2222-222222222222"
+  displayName: "Production"
+  parent: null
+  type: "11111111-1111-1111-1111-111111111111"
+---
+version: emeland.io/v1
+kind: System
+spec:
+  systemId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+  displayName: "Order Service"
+  description: "Handles order processing"
+  abstract: false
+---
+version: emeland.io/v1
+kind: API
+spec:
+  apiId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+  displayName: "Order API"
+  description: "REST API for orders"
+  type: "OpenAPI"
+  system: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+`
+	})
+
+	It("loads the issue #24 example into the model", func() {
+		sink := events.NewListSink()
+		m, err := model.NewModel(sink)
+		Expect(err).NotTo(HaveOccurred())
+
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "model.yaml")
+		Expect(os.WriteFile(path, []byte(issueExampleYAML), 0644)).To(Succeed())
+
+		res, err := filesensor.ProcessFile(path, m)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Applied).To(Equal(3))
+		Expect(res.Failed).To(BeEmpty())
+
+		ctxID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+		ctx := m.GetContextById(ctxID)
+		Expect(ctx).NotTo(BeNil())
+		Expect(ctx.GetDisplayName()).To(Equal("Production"))
+		Expect(ctx.GetAnnotations().GetValue(filesensor.AnnotationContextTypeID)).To(Equal("11111111-1111-1111-1111-111111111111"))
+
+		sysID := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+		sys := m.GetSystemById(sysID)
+		Expect(sys).NotTo(BeNil())
+		Expect(sys.GetDisplayName()).To(Equal("Order Service"))
+
+		apiID := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+		api := m.GetApiById(apiID)
+		Expect(api).NotTo(BeNil())
+		Expect(api.GetDisplayName()).To(Equal("Order API"))
+		Expect(api.GetType()).To(Equal(model.OpenAPI))
+		Expect(api.GetSystem()).NotTo(BeNil())
+		Expect(api.GetSystem().SystemId).To(Equal(sysID))
+	})
+
+	It("applies valid documents and skips invalid ones in the same file", func() {
+		data := `---
+version: "emeland.io/v1"
+kind: Context
+spec:
+  daf: "22222222-2222-2222-2222-222222222222"
+  fa: "Production"
+---
+version: "emeland.io/v1"
+kind: Context
+spec:
+  contextId: "11111111-2222-2222-2222-222222222222"
+  displayName: "Staging"
+  parent: null
+  type: "11111111-1111-1111-1111-111111111111"
+`
+		sink := events.NewListSink()
+		m, err := model.NewModel(sink)
+		Expect(err).NotTo(HaveOccurred())
+
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "mixed.yaml")
+		Expect(os.WriteFile(path, []byte(data), 0644)).To(Succeed())
+
+		res, err := filesensor.ProcessFile(path, m)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Applied).To(Equal(1))
+		Expect(res.Failed).To(HaveLen(1))
+		Expect(res.Failed[0].Index).To(Equal(0))
+
+		ctx := m.GetContextById(uuid.MustParse("11111111-2222-2222-2222-222222222222"))
+		Expect(ctx).NotTo(BeNil())
+		Expect(ctx.GetDisplayName()).To(Equal("Staging"))
+	})
+})
+
+var _ = Describe("ApplyDocument", func() {
+	var m model.Model
+
+	BeforeEach(func() {
+		sink := events.NewListSink()
+		var err error
+		m, err = model.NewModel(sink)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when the API type is invalid", func() {
+		It("returns an error", func() {
+			doc := filesensor.Document{
+				Version: "emeland.io/v1",
+				Kind:    filesensor.DocumentKind(events.APIResource),
+				Spec: map[string]any{
+					"apiId":       "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+					"displayName": "X",
+					"system":      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+					"type":        "NotARealType",
+				},
+			}
+			Expect(filesensor.ApplyDocument(doc, m)).To(MatchError(ContainSubstring("invalid API type")))
+		})
+	})
+
+	Context("when the kind is not supported", func() {
+		It("returns an error", func() {
+			doc := filesensor.Document{
+				Version: "emeland.io/v1",
+				Kind:    filesensor.DocumentKind(events.AnnotationsResource),
+				Spec: map[string]any{
+					"componentId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+					"displayName": "X",
+				},
+			}
+			Expect(filesensor.ApplyDocument(doc, m)).To(MatchError(ContainSubstring("unsupported kind")))
+		})
+	})
+
+	Context("when systemId is used instead of system for an API", func() {
+		It("accepts the document after the system exists", func() {
+			Expect(filesensor.ApplyDocument(filesensor.Document{
+				Version: "emeland.io/v1",
+				Kind:    filesensor.DocumentKind(events.SystemResource),
+				Spec: map[string]any{
+					"systemId":    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+					"displayName": "S",
+				},
+			}, m)).To(Succeed())
+
+			Expect(filesensor.ApplyDocument(filesensor.Document{
+				Version: "emeland.io/v1",
+				Kind:    filesensor.DocumentKind(events.APIResource),
+				Spec: map[string]any{
+					"apiId":       "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+					"displayName": "A",
+					"systemId":    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+				},
+			}, m)).To(Succeed())
+
+			api := m.GetApiById(uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+			Expect(api).NotTo(BeNil())
+		})
+	})
+})

--- a/pkg/filesensor/parse.go
+++ b/pkg/filesensor/parse.go
@@ -1,0 +1,106 @@
+package filesensor
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"go.emeland.io/modelsrv/pkg/events"
+	"gopkg.in/yaml.v3"
+)
+
+// DocumentKind is the resource discriminator for a [Document]; values are [events.ResourceType] and match the YAML `kind` field.
+type DocumentKind events.ResourceType
+
+var documentKinds = map[events.ResourceType]struct{}{
+	events.ContextResource:     {},
+	events.ContextTypeResource: {},
+	events.NodeResource:        {},
+	events.NodeTypeResource:    {},
+
+	events.SystemResource:            {},
+	events.SystemInstanceResource:    {},
+	events.APIResource:               {},
+	events.APIInstanceResource:       {},
+	events.ComponentResource:         {},
+	events.ComponentInstanceResource: {},
+	events.FindingResource:           {},
+	events.FindingTypeResource:       {},
+}
+
+// ResourceType returns the underlying [events.ResourceType].
+func (k DocumentKind) ResourceType() events.ResourceType {
+	return events.ResourceType(k)
+}
+
+// UnmarshalYAML accepts only resource kinds valid for a top-level document (or empty for blank placeholders).
+func (k *DocumentKind) UnmarshalYAML(node *yaml.Node) error {
+	var s string
+	if err := node.Decode(&s); err != nil {
+		return err
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		*k = DocumentKind(events.UnknownResourceType)
+		return nil
+	}
+	rt := events.ParseResourceType(s)
+	if rt == events.UnknownResourceType {
+		return fmt.Errorf("unsupported kind %q", s)
+	}
+	if _, ok := documentKinds[rt]; !ok {
+		return fmt.Errorf("unsupported kind %q", s)
+	}
+	*k = DocumentKind(rt)
+	return nil
+}
+
+// Document is one top-level resource in a multi-doc YAML stream.
+type Document struct {
+	Version string         `yaml:"version"`
+	Kind    DocumentKind   `yaml:"kind"`
+	Spec    map[string]any `yaml:"spec"`
+}
+
+// DecodeDocuments decodes a multi-document YAML stream into separate [Document] values.
+func DecodeDocuments(data []byte) ([]Document, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+
+	var docs []Document
+	for {
+		var doc Document
+		err := dec.Decode(&doc)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		// Ignore completely empty YAML documents (e.g. stray `---` separators).
+		if strings.TrimSpace(doc.Version) == "" && doc.Kind.ResourceType() == events.UnknownResourceType && doc.Spec == nil {
+			continue
+		}
+		if strings.TrimSpace(doc.Version) == "" {
+			return nil, fmt.Errorf("document %d: missing version", len(docs))
+		}
+		if doc.Kind.ResourceType() == events.UnknownResourceType {
+			return nil, fmt.Errorf("document %d: missing kind", len(docs))
+		}
+		if doc.Spec == nil {
+			return nil, fmt.Errorf("document %d: missing spec", len(docs))
+		}
+		docs = append(docs, doc)
+	}
+	if len(docs) == 0 {
+		return nil, fmt.Errorf("no YAML documents found")
+	}
+	return docs, nil
+}
+
+// ValidVersion reports whether v uses an accepted emeland.io API version prefix.
+func ValidVersion(v string) bool {
+	v = strings.TrimSpace(v)
+	return strings.HasPrefix(v, "emeland.io/")
+}

--- a/pkg/filesensor/process.go
+++ b/pkg/filesensor/process.go
@@ -1,0 +1,75 @@
+package filesensor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.emeland.io/modelsrv/pkg/model"
+)
+
+func isYAMLFileName(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.HasSuffix(lower, ".yaml") || strings.HasSuffix(lower, ".yml")
+}
+
+// DocumentError records a single document that could not be applied.
+type DocumentError struct {
+	Index int   // 0-based index within the file
+	Err   error // validation or apply error
+}
+
+func (e DocumentError) Error() string {
+	return fmt.Sprintf("document %d: %v", e.Index, e.Err)
+}
+
+func (e DocumentError) Unwrap() error {
+	return e.Err
+}
+
+// ProcessFileResult is the outcome of applying a multi-document YAML file.
+type ProcessFileResult struct {
+	Applied int             // documents successfully applied
+	Failed  []DocumentError // documents skipped (logged by caller)
+}
+
+// ProcessFile reads a YAML file and applies each document to m in order.
+// Invalid documents are skipped; processing continues for the rest of the file.
+// A non-nil error is returned only for I/O failures or YAML stream decode errors (not per-document apply errors).
+func ProcessFile(path string, m model.Model) (ProcessFileResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ProcessFileResult{}, err
+	}
+	docs, err := DecodeDocuments(data)
+	if err != nil {
+		return ProcessFileResult{}, err
+	}
+	var out ProcessFileResult
+	for i := range docs {
+		if err := ApplyDocument(docs[i], m); err != nil {
+			out.Failed = append(out.Failed, DocumentError{Index: i, Err: err})
+			continue
+		}
+		out.Applied++
+	}
+	return out, nil
+}
+
+func scanDir(dir string, process func(path string)) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if !isYAMLFileName(e.Name()) {
+			continue
+		}
+		process(filepath.Join(dir, e.Name()))
+	}
+	return nil
+}

--- a/pkg/filesensor/sensor.go
+++ b/pkg/filesensor/sensor.go
@@ -1,0 +1,124 @@
+package filesensor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"go.emeland.io/modelsrv/pkg/model"
+	"go.uber.org/zap"
+)
+
+const debounceDelay = 250 * time.Millisecond
+
+// Start watches dir for .yaml/.yml files, applies existing files once, then watches for changes.
+// It returns immediately; work runs in a background goroutine until ctx is cancelled.
+func Start(ctx context.Context, dir string, m model.Model, log *zap.SugaredLogger) {
+	if log == nil {
+		log = zap.NewNop().Sugar()
+	}
+	go run(ctx, dir, m, log)
+}
+
+func run(ctx context.Context, dir string, m model.Model, log *zap.SugaredLogger) {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		log.Errorw("filesensor: could not create data directory", "dir", dir, "error", err.Error())
+		return
+	}
+
+	apply := func(path string) {
+		res, err := ProcessFile(path, m)
+		if err != nil {
+			log.Errorw("filesensor: could not read or parse YAML file", "path", path, "error", err.Error())
+			return
+		}
+		for _, docErr := range res.Failed {
+			log.Errorw("filesensor: document skipped", "path", path, "document", docErr.Index, "error", docErr.Err.Error())
+		}
+		if res.Applied > 0 {
+			log.Infow("filesensor: applied YAML documents", "path", path, "applied", res.Applied, "skipped", len(res.Failed))
+		} else if len(res.Failed) > 0 {
+			log.Errorw("filesensor: no documents applied", "path", path, "skipped", len(res.Failed))
+		}
+	}
+
+	if err := scanDir(dir, apply); err != nil {
+		log.Errorw("filesensor: initial scan failed", "dir", dir, "error", err.Error())
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Errorw("filesensor: watcher create failed", "error", err.Error())
+		return
+	}
+	defer func() {
+		if err := watcher.Close(); err != nil {
+			log.Errorw("filesensor: watcher close failed", "error", err.Error())
+		}
+	}()
+
+	if err := watcher.Add(dir); err != nil {
+		log.Errorw("filesensor: watch add failed", "dir", dir, "error", err.Error())
+		return
+	}
+
+	var mu sync.Mutex
+	timers := make(map[string]*time.Timer)
+	schedule := func(path string) {
+		if !isYAMLFileName(filepath.Base(path)) {
+			return
+		}
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			return
+		}
+		parent := filepath.Dir(path)
+		absParent, err := filepath.Abs(parent)
+		if err != nil {
+			return
+		}
+		if absParent != absDir {
+			return
+		}
+
+		mu.Lock()
+		if t, ok := timers[path]; ok {
+			t.Stop()
+		}
+		timers[path] = time.AfterFunc(debounceDelay, func() {
+			mu.Lock()
+			delete(timers, path)
+			mu.Unlock()
+
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			apply(path)
+		})
+		mu.Unlock()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			if ev.Has(fsnotify.Create) || ev.Has(fsnotify.Write) || ev.Has(fsnotify.Rename) {
+				schedule(ev.Name)
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Errorw("filesensor: watcher error", "error", err.Error())
+		}
+	}
+}

--- a/test/fixtures/simple_system.yaml
+++ b/test/fixtures/simple_system.yaml
@@ -32,4 +32,6 @@ version: emeland.io/v1alpha1
 kind: API
 spec:
   apiId: c649f2f3-462b-4a6d-8337-0d2e7403c44d
+  displayName: Orders API
+  type: OpenAPI
   systemId: b4eaa9f0-0242-4a26-9496-fa2b1a3b9330


### PR DESCRIPTION
- Adds pkg/filesensor: watches --data-dir with fsnotify (debounced), scans .yaml/.yml on startup, parses multi-doc YAML, maps kind + spec into model.Model Add* calls.
- Wires into modelsrv server: starts the watcher (resolved absolute data-dir) before the web listener.
- Adds tests (+ a small YAML fixture), fsnotify in go.mod, and minor .gitignore / endpoint updates.

**Outcome**: YAML in the data directory is applied to the running model automatically when files appear or change, so the API reflects those definitions without a separate apply command.