### PR TITLE
A number of small fixes and cleanups

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,9 +21,9 @@ jobs:
       with:
         go-version: '1.24'
 
-    - name: Install mockgen
-      run: go install go.uber.org/mock/mockgen@latest
-      
+    - name: Install tools
+      run: make tools
+
     - name: Generate
       run: go generate -v ./...
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ $(LOCALBIN):
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.11.3
 
+MOCKGEN = $(LOCALBIN)/mockgen
+MOCKGEN_VERSION ?= v0.6.0
+
+
 .PHONY: build
 build: test ## Build the project binary.
 	go build -ldflags "-s -w" -o bin/modelsrv ./cmd/modelsrv
@@ -42,6 +46,11 @@ golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	# v2.x releases use the /v2 module path (see https://golangci-lint.run/welcome/install/#install-from-sources)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+.PHONY: tools
+tools: $(MOCKGEN)
+$(MOCKGEN): $(LOCALBIN)
+	$(call go-install-tool,$(MOCKGEN),go.uber.org/mock/mockgen,$(MOCKGEN_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/internal/oapi/event_apply.go
+++ b/internal/oapi/event_apply.go
@@ -312,18 +312,7 @@ func oapiVersionToModel(v *Version) model.Version {
 
 func parseAPIType(v interface{}) model.ApiType {
 	s, _ := v.(string)
-	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "openapi":
-		return model.OpenAPI
-	case "graphql":
-		return model.GraphQL
-	case "grpc":
-		return model.GRPC
-	case "other":
-		return model.Other
-	default:
-		return model.Unknown
-	}
+	return model.ParseApiType(strings.TrimSpace(s))
 }
 
 func mergeOapiAnnotations(dst model.Annotations, src *[]Annotation) {

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package events
 
-//go:generate mockgen -destination=../mocks/mock_events.go -package=mocks . EventSink,EventManager
+//go:generate ../../bin/mockgen -destination=../mocks/mock_events.go -package=mocks . EventSink,EventManager
 
 import (
 	"context"

--- a/pkg/model/annotations.go
+++ b/pkg/model/annotations.go
@@ -9,7 +9,7 @@ import (
 	"go.emeland.io/modelsrv/pkg/events"
 )
 
-//go:generate mockgen -destination=../mocks/mock_annotations.go -package=mocks . Annotations
+//go:generate ../../bin/mockgen -destination=../mocks/mock_annotations.go -package=mocks . Annotations
 
 // ensure Annotations interface is implemented correctly
 var _ Annotations = (*annotationsData)(nil)

--- a/pkg/model/api_types.go
+++ b/pkg/model/api_types.go
@@ -1,5 +1,7 @@
 package model
 
+import "strings"
+
 // ApiType classifies an API (aligned with the Emerging Enterprise Landscape OpenAPI enum).
 type ApiType int
 
@@ -11,20 +13,29 @@ const (
 	Other
 )
 
+var apiTypeValues = map[ApiType]string{
+	Unknown: "Unknown",
+	OpenAPI: "OpenAPI",
+	GraphQL: "GraphQL",
+	GRPC:    "GRPC",
+	Other:   "Other",
+}
+
 // String returns the API type label used in APIs and events. Unknown is returned for invalid values.
 func (t ApiType) String() string {
-	switch t {
-	case Unknown:
-		return "Unknown"
-	case OpenAPI:
-		return "OpenAPI"
-	case GraphQL:
-		return "GraphQL"
-	case GRPC:
-		return "GRPC"
-	case Other:
-		return "Other"
-	default:
-		return "Unknown"
+	if label, exists := apiTypeValues[t]; exists {
+		return label
 	}
+	return apiTypeValues[Unknown]
+}
+
+// ParseApiType parses a string into an ApiType, ignoring case. Unknown is returned for invalid values.
+// The function does not trim the input string, so leading/trailing whitespace will cause parsing to fail. Use strings.TrimSpace before calling if needed.
+func ParseApiType(s string) ApiType {
+	for key, val := range apiTypeValues {
+		if strings.EqualFold(val, s) {
+			return key
+		}
+	}
+	return Unknown
 }

--- a/pkg/model/structure.go
+++ b/pkg/model/structure.go
@@ -1,8 +1,8 @@
 //go:generate go run generate_events.go
 package model
 
-//go:generate mockgen -destination=../mocks/mock_model.go -package=mocks . Model
-//go:generate mockgen -destination=../mocks/mock_finding_type.go -package=mocks . FindingType
+//go:generate ../../bin/mockgen -destination=../mocks/mock_model.go -package=mocks . Model
+//go:generate ../../bin/mockgen -destination=../mocks/mock_finding_type.go -package=mocks . FindingType
 
 import (
 	"context"


### PR DESCRIPTION
- **Add make target to install required tools**: This makes installing missing tools (currently mockgen and golintcli) easier
- **Fix path to tools binaries for mockgen**: will use the currently installed copy of the tool
- **Use lookup table for determining API types**: Improve DRYness of code, by providing a lookup mechanism for the API type.