### PR TITLE
Implement event filter chain

### DIFF
--- a/cmd/modelsrv/server.go
+++ b/cmd/modelsrv/server.go
@@ -10,10 +10,9 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
-	eventmgr "go.emeland.io/modelsrv/internal/events"
+	"go.emeland.io/modelsrv/pkg/backend"
 	"go.emeland.io/modelsrv/pkg/endpoint"
 	"go.emeland.io/modelsrv/pkg/filesensor"
-	"go.emeland.io/modelsrv/pkg/model"
 	"go.uber.org/zap"
 )
 
@@ -38,21 +37,9 @@ var serverCmd = &cobra.Command{
 
 		logger := log.Sugar()
 
-		eventMgr, err := eventmgr.NewEventManager()
+		b, err := backend.New()
 		if err != nil {
-			logger.Errorw("error creating event manager", "error", err)
-			return
-		}
-
-		sink, err := eventMgr.GetSink()
-		if err != nil {
-			logger.Errorw("error getting event sink", "error", err)
-			return
-		}
-
-		model, err := model.NewModel(sink)
-		if err != nil {
-			logger.Errorw("error creating model", "error", err)
+			logger.Errorw("error creating backend", "error", err)
 			return
 		}
 
@@ -70,9 +57,9 @@ var serverCmd = &cobra.Command{
 		logger.Infof("Swagger UI: http://%s/swagger/", serviceAddr)
 		logger.Info("file sensor: watching for YAML in data directory")
 
-		filesensor.Start(context.Background(), dataPath, model, logger)
+		filesensor.Start(context.Background(), dataPath, b.GetModel(), logger)
 
-		if err := endpoint.StarWebListener(model, eventMgr, serviceAddr); err != nil {
+		if err := endpoint.StarWebListener(b.GetModel(), b.GetEventManager(), serviceAddr); err != nil {
 			logger.Errorw("error starting web listener", "error", err)
 			return
 		}

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -1,0 +1,95 @@
+// Package backend provides a [Backend] that wires together a [model.Model],
+// an [eventfilter.Chain], and an [events.EventManager] into a single cohesive
+// unit.
+//
+// Construction order:
+//  1. Create the EventManager and obtain its recording sink.
+//  2. Create a Chain with a nil model placeholder.
+//  3. Wrap the recording sink in a [eventfilter.FilteringSink] backed by the chain.
+//  4. Create the Model using the FilteringSink — every model mutation now flows
+//     through the chain before reaching the recording sink.
+//  5. Back-fill the chain with the now-constructed model via SetModel.
+//
+// This resolves the construction cycle: Chain needs Model, Model needs sink,
+// sink needs Chain.
+package backend
+
+import (
+	eventmgr "go.emeland.io/modelsrv/internal/events"
+	"go.emeland.io/modelsrv/pkg/eventfilter"
+	"go.emeland.io/modelsrv/pkg/events"
+	"go.emeland.io/modelsrv/pkg/model"
+)
+
+// Backend bundles the model, the filter chain, and the event manager.
+// External consumers (sensors, the web endpoint) retrieve only the part they need.
+type Backend interface {
+	// GetModel returns the landscape model.
+	// Sensors call Add*/Delete* on it to mutate state; those mutations flow
+	// through the FilteringSink and the Chain before reaching the EventManager.
+	GetModel() model.Model
+
+	// GetChain returns the filter chain.
+	// Sensors register their FilterFuncs here to intercept and enrich events.
+	GetChain() eventfilter.Chain
+
+	// GetEventManager returns the event manager.
+	// Used by the web endpoint to serve subscribers and manage sequence IDs.
+	GetEventManager() events.EventManager
+}
+
+type backendData struct {
+	model    model.Model
+	chain    eventfilter.Chain
+	eventMgr events.EventManager
+}
+
+// New constructs a fully wired Backend.
+//
+// The returned Backend has an empty filter chain; callers register their
+// [eventfilter.FilterFunc]s via [Backend.GetChain].Register before feeding
+// events into the model.
+func New() (Backend, error) {
+	eventMgr, err := eventmgr.NewEventManager()
+	if err != nil {
+		return nil, err
+	}
+
+	recordingSink, err := eventMgr.GetSink()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the chain with a nil model; the model is back-filled below after
+	// the Model is constructed (SetModel breaks the construction cycle).
+	chain := eventfilter.NewChain(nil)
+	filteredSink := eventfilter.NewFilteringSink(chain, recordingSink)
+
+	m, err := model.NewModel(filteredSink)
+	if err != nil {
+		return nil, err
+	}
+
+	chain.SetModel(m)
+
+	return &backendData{
+		model:    m,
+		chain:    chain,
+		eventMgr: eventMgr,
+	}, nil
+}
+
+// GetModel implements [Backend].
+func (b *backendData) GetModel() model.Model {
+	return b.model
+}
+
+// GetChain implements [Backend].
+func (b *backendData) GetChain() eventfilter.Chain {
+	return b.chain
+}
+
+// GetEventManager implements [Backend].
+func (b *backendData) GetEventManager() events.EventManager {
+	return b.eventMgr
+}

--- a/pkg/backend/backend_suite_test.go
+++ b/pkg/backend/backend_suite_test.go
@@ -1,0 +1,13 @@
+package backend_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBackend(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pkg/backend Suite")
+}

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -1,0 +1,140 @@
+package backend_test
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"go.emeland.io/modelsrv/pkg/backend"
+	"go.emeland.io/modelsrv/pkg/eventfilter"
+	"go.emeland.io/modelsrv/pkg/events"
+	"go.emeland.io/modelsrv/pkg/model"
+	"go.emeland.io/modelsrv/pkg/model/common"
+)
+
+var _ = Describe("Backend", func() {
+	Describe("New", func() {
+		It("constructs without error", func() {
+			b, err := backend.New()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(b).NotTo(BeNil())
+		})
+
+		It("exposes a non-nil Model", func() {
+			b, _ := backend.New()
+			Expect(b.GetModel()).NotTo(BeNil())
+		})
+
+		It("exposes a non-nil Chain", func() {
+			b, _ := backend.New()
+			Expect(b.GetChain()).NotTo(BeNil())
+		})
+
+		It("exposes a non-nil EventManager", func() {
+			b, _ := backend.New()
+			Expect(b.GetEventManager()).NotTo(BeNil())
+		})
+	})
+
+	Describe("wiring: model mutations flow through the filter chain", func() {
+		It("a registered FilterFunc receives events emitted by model mutations", func() {
+			b, err := backend.New()
+			Expect(err).NotTo(HaveOccurred())
+
+			var intercepted []events.Event
+			b.GetChain().Register(func(_ model.Model, ev events.Event) []events.Event {
+				intercepted = append(intercepted, ev)
+				return []events.Event{ev}
+			})
+
+			sys := model.MakeTestSystem(b.GetModel().GetSink(), uuid.New(), "test-sys", common.Version{})
+			Expect(b.GetModel().AddSystem(sys)).To(Succeed())
+
+			Expect(intercepted).NotTo(BeEmpty())
+			Expect(intercepted[0].ResourceType).To(Equal(events.SystemResource))
+		})
+
+		It("the chain receives the same Model instance that Backend constructed", func() {
+			b, err := backend.New()
+			Expect(err).NotTo(HaveOccurred())
+
+			var receivedModel model.Model
+			b.GetChain().Register(func(m model.Model, ev events.Event) []events.Event {
+				receivedModel = m
+				return []events.Event{ev}
+			})
+
+			sys := model.MakeTestSystem(b.GetModel().GetSink(), uuid.New(), "check-model", common.Version{})
+			Expect(b.GetModel().AddSystem(sys)).To(Succeed())
+
+			Expect(receivedModel).To(BeIdenticalTo(b.GetModel()))
+		})
+
+		It("a filter can expand model events with additional events", func() {
+			b, err := backend.New()
+			Expect(err).NotTo(HaveOccurred())
+
+			var count int
+			b.GetChain().Register(func(_ model.Model, ev events.Event) []events.Event {
+				count++
+				extra := events.Event{
+					ResourceType: events.FindingResource,
+					Operation:    events.CreateOperation,
+					ResourceId:   uuid.New(),
+				}
+				return []events.Event{ev, extra}
+			})
+
+			sys := model.MakeTestSystem(b.GetModel().GetSink(), uuid.New(), "expand-sys", common.Version{})
+			Expect(b.GetModel().AddSystem(sys)).To(Succeed())
+
+			Expect(count).To(BeNumerically(">", 0))
+			seqID, err := b.GetEventManager().GetCurrentSequenceId(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(seqID).To(Equal(uint64(2))) // 1 for the system creation, 1 for the finding creation
+		})
+	})
+
+	Describe("Chain.SetModel", func() {
+		It("updates the model reference used by subsequent Apply calls", func() {
+			chain := eventfilter.NewChain(nil)
+
+			var capturedModel model.Model
+			chain.Register(func(m model.Model, ev events.Event) []events.Event {
+				capturedModel = m
+				return []events.Event{ev}
+			})
+
+			b, err := backend.New()
+			Expect(err).NotTo(HaveOccurred())
+
+			chain.SetModel(b.GetModel())
+			chain.Apply(events.Event{
+				ResourceType: events.SystemResource,
+				Operation:    events.CreateOperation,
+				ResourceId:   uuid.New(),
+			})
+
+			Expect(capturedModel).To(BeIdenticalTo(b.GetModel()))
+		})
+
+		It("is safe to call after filters are already registered", func() {
+			chain := eventfilter.NewChain(nil)
+			chain.Register(func(_ model.Model, ev events.Event) []events.Event {
+				return []events.Event{ev}
+			})
+
+			b, _ := backend.New()
+			Expect(func() { chain.SetModel(b.GetModel()) }).NotTo(Panic())
+
+			result := chain.Apply(events.Event{
+				ResourceType: events.NodeResource,
+				Operation:    events.CreateOperation,
+				ResourceId:   uuid.New(),
+			})
+			Expect(result).To(HaveLen(1))
+		})
+	})
+})

--- a/pkg/eventfilter/chain.go
+++ b/pkg/eventfilter/chain.go
@@ -1,0 +1,87 @@
+package eventfilter
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+	"go.emeland.io/modelsrv/pkg/events"
+	"go.emeland.io/modelsrv/pkg/model"
+)
+
+type entry struct {
+	id FilterID
+	fn FilterFunc
+}
+
+type chainData struct {
+	model   model.Model
+	mu      sync.RWMutex
+	filters []entry
+}
+
+var _ Chain = (*chainData)(nil)
+
+// NewChain creates a new filter Chain associated with m.
+// The model is passed to every FilterFunc on each Apply call so that
+// filter functions can inspect the current landscape state.
+func NewChain(m model.Model) Chain {
+	return &chainData{
+		model:   m,
+		filters: make([]entry, 0),
+	}
+}
+
+// Register implements [Chain].
+func (c *chainData) Register(fn FilterFunc) FilterID {
+	id := FilterID(uuid.New())
+	c.mu.Lock()
+	c.filters = append(c.filters, entry{id: id, fn: fn})
+	c.mu.Unlock()
+	return id
+}
+
+// Unregister implements [Chain].
+func (c *chainData) Unregister(id FilterID) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i, e := range c.filters {
+		if e.id == id {
+			c.filters = append(c.filters[:i], c.filters[i+1:]...)
+			return
+		}
+	}
+}
+
+// SetModel implements [Chain].
+func (c *chainData) SetModel(m model.Model) {
+	c.mu.Lock()
+	c.model = m
+	c.mu.Unlock()
+}
+
+// Apply implements [Chain].
+//
+// It snapshots the current filter slice and model reference, then flat-maps
+// each FilterFunc over the event batch: every filter receives each event in
+// the current batch and its outputs replace the batch for the next filter.
+func (c *chainData) Apply(ev events.Event) []events.Event {
+	c.mu.RLock()
+	snapshot := make([]entry, len(c.filters))
+	copy(snapshot, c.filters)
+	m := c.model
+	c.mu.RUnlock()
+
+	if len(snapshot) == 0 {
+		return []events.Event{ev}
+	}
+
+	current := []events.Event{ev}
+	for _, e := range snapshot {
+		var next []events.Event
+		for _, inEv := range current {
+			next = append(next, e.fn(m, inEv)...)
+		}
+		current = next
+	}
+	return current
+}

--- a/pkg/eventfilter/chain_test.go
+++ b/pkg/eventfilter/chain_test.go
@@ -1,0 +1,265 @@
+package eventfilter_test
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gomock "go.uber.org/mock/gomock"
+
+	"go.emeland.io/modelsrv/pkg/eventfilter"
+	"go.emeland.io/modelsrv/pkg/events"
+	"go.emeland.io/modelsrv/pkg/mocks"
+	"go.emeland.io/modelsrv/pkg/model"
+)
+
+// makeEvent is a test helper that builds a minimal events.Event.
+func makeEvent(rt events.ResourceType) events.Event {
+	return events.Event{
+		ResourceType: rt,
+		Operation:    events.CreateOperation,
+		ResourceId:   uuid.New(),
+	}
+}
+
+// passThroughFn is a FilterFunc that returns its input event unchanged.
+func passThroughFn(_ model.Model, ev events.Event) []events.Event {
+	return []events.Event{ev}
+}
+
+var _ = Describe("Chain", func() {
+	var (
+		ctrl      *gomock.Controller
+		mockModel *mocks.MockModel
+		chain     eventfilter.Chain
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockModel = mocks.NewMockModel(ctrl)
+		chain = eventfilter.NewChain(mockModel)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("Apply with no registered filters", func() {
+		It("returns the original event unchanged", func() {
+			ev := makeEvent(events.SystemResource)
+			result := chain.Apply(ev)
+			Expect(result).To(HaveLen(1))
+			Expect(result[0]).To(Equal(ev))
+		})
+	})
+
+	Describe("Apply with a single pass-through filter", func() {
+		It("returns the original event unchanged", func() {
+			chain.Register(passThroughFn)
+			ev := makeEvent(events.APIResource)
+			result := chain.Apply(ev)
+			Expect(result).To(HaveLen(1))
+			Expect(result[0]).To(Equal(ev))
+		})
+	})
+
+	Describe("Apply with a suppressing filter", func() {
+		It("returns an empty slice", func() {
+			chain.Register(func(_ model.Model, _ events.Event) []events.Event {
+				return nil
+			})
+			ev := makeEvent(events.NodeResource)
+			result := chain.Apply(ev)
+			Expect(result).To(BeEmpty())
+		})
+	})
+
+	Describe("Apply with an expanding filter", func() {
+		It("returns multiple events", func() {
+			extra := makeEvent(events.FindingResource)
+			chain.Register(func(_ model.Model, ev events.Event) []events.Event {
+				return []events.Event{ev, extra}
+			})
+			ev := makeEvent(events.SystemResource)
+			result := chain.Apply(ev)
+			Expect(result).To(HaveLen(2))
+			Expect(result[0]).To(Equal(ev))
+			Expect(result[1]).To(Equal(extra))
+		})
+	})
+
+	Describe("Apply with multiple filters (flatMap composition)", func() {
+		It("applies each filter to every event in the current batch in order", func() {
+			finding := makeEvent(events.FindingResource)
+			// filter 1: expand ev → [ev, finding]
+			chain.Register(func(_ model.Model, ev events.Event) []events.Event {
+				return []events.Event{ev, finding}
+			})
+			// filter 2: pass-through
+			chain.Register(passThroughFn)
+
+			ev := makeEvent(events.APIResource)
+			result := chain.Apply(ev)
+			// filter 1 produces [ev, finding]; filter 2 receives both and returns both unchanged
+			Expect(result).To(HaveLen(2))
+			Expect(result[0]).To(Equal(ev))
+			Expect(result[1]).To(Equal(finding))
+		})
+
+		It("suppressing in the second filter empties the batch", func() {
+			chain.Register(passThroughFn)
+			chain.Register(func(_ model.Model, _ events.Event) []events.Event {
+				return nil
+			})
+			result := chain.Apply(makeEvent(events.ContextResource))
+			Expect(result).To(BeEmpty())
+		})
+	})
+
+	Describe("Register", func() {
+		It("returns a distinct FilterID on each call", func() {
+			id1 := chain.Register(passThroughFn)
+			id2 := chain.Register(passThroughFn)
+			id3 := chain.Register(passThroughFn)
+			Expect(id1).NotTo(Equal(id2))
+			Expect(id2).NotTo(Equal(id3))
+			Expect(id1).NotTo(Equal(id3))
+		})
+	})
+
+	Describe("Unregister", func() {
+		It("removes only the filter with the given ID", func() {
+			var called []string
+
+			id1 := chain.Register(func(_ model.Model, ev events.Event) []events.Event {
+				called = append(called, "A")
+				return []events.Event{ev}
+			})
+			_ = chain.Register(func(_ model.Model, ev events.Event) []events.Event {
+				called = append(called, "B")
+				return []events.Event{ev}
+			})
+
+			chain.Unregister(id1)
+			chain.Apply(makeEvent(events.SystemResource))
+			Expect(called).To(Equal([]string{"B"}))
+		})
+
+		It("is a no-op for an unknown FilterID", func() {
+			chain.Register(passThroughFn)
+			unknownID := eventfilter.FilterID(uuid.New())
+			Expect(func() { chain.Unregister(unknownID) }).NotTo(Panic())
+			result := chain.Apply(makeEvent(events.NodeResource))
+			Expect(result).To(HaveLen(1))
+		})
+	})
+
+	Describe("FilterFunc receives the model", func() {
+		It("passes the model injected at NewChain to each filter", func() {
+			var received model.Model
+			chain.Register(func(m model.Model, ev events.Event) []events.Event {
+				received = m
+				return []events.Event{ev}
+			})
+			chain.Apply(makeEvent(events.SystemResource))
+			Expect(received).To(BeIdenticalTo(mockModel))
+		})
+	})
+
+	Describe("Concurrency", func() {
+		It("does not race when Register and Apply run concurrently", func() {
+			const goroutines = 20
+			var wg sync.WaitGroup
+			wg.Add(goroutines * 2)
+
+			for i := 0; i < goroutines; i++ {
+				go func() {
+					defer wg.Done()
+					chain.Register(passThroughFn)
+				}()
+				go func() {
+					defer wg.Done()
+					chain.Apply(makeEvent(events.APIResource))
+				}()
+			}
+			wg.Wait()
+		})
+	})
+})
+
+var _ = Describe("FilteringSink", func() {
+	var (
+		ctrl       *gomock.Controller
+		mockModel  *mocks.MockModel
+		downstream *events.ListSink
+		chain      eventfilter.Chain
+		sink       events.EventSink
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockModel = mocks.NewMockModel(ctrl)
+		downstream = events.NewListSink()
+		chain = eventfilter.NewChain(mockModel)
+		sink = eventfilter.NewFilteringSink(chain, downstream)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("passes the event through to downstream when the chain is empty", func() {
+		id := uuid.New()
+		Expect(sink.Receive(events.SystemResource, events.CreateOperation, id)).To(Succeed())
+		evs := downstream.GetEvents()
+		Expect(evs).To(HaveLen(1))
+		Expect(evs[0].ResourceType).To(Equal(events.SystemResource))
+		Expect(evs[0].Operation).To(Equal(events.CreateOperation))
+		Expect(evs[0].ResourceId).To(Equal(id))
+	})
+
+	It("suppresses the event when the chain returns empty", func() {
+		chain.Register(func(_ model.Model, _ events.Event) []events.Event { return nil })
+		Expect(sink.Receive(events.NodeResource, events.CreateOperation, uuid.New())).To(Succeed())
+		Expect(downstream.GetEvents()).To(BeEmpty())
+	})
+
+	It("forwards all expanded events to downstream in order", func() {
+		extra := makeEvent(events.FindingResource)
+		chain.Register(func(_ model.Model, ev events.Event) []events.Event {
+			return []events.Event{ev, extra}
+		})
+		id := uuid.New()
+		Expect(sink.Receive(events.APIResource, events.UpdateOperation, id)).To(Succeed())
+		evs := downstream.GetEvents()
+		Expect(evs).To(HaveLen(2))
+		Expect(evs[0].ResourceId).To(Equal(id))
+		Expect(evs[1]).To(Equal(extra))
+	})
+
+	It("stops forwarding and returns the error on downstream failure", func() {
+		errSink := &errorSink{err: fmt.Errorf("downstream error")}
+		failingSink := eventfilter.NewFilteringSink(chain, errSink)
+
+		extra := makeEvent(events.FindingResource)
+		chain.Register(func(_ model.Model, ev events.Event) []events.Event {
+			return []events.Event{ev, extra}
+		})
+		err := failingSink.Receive(events.SystemResource, events.CreateOperation, uuid.New())
+		Expect(err).To(MatchError("downstream error"))
+		Expect(errSink.calls).To(Equal(1))
+	})
+})
+
+// errorSink is a test double that always returns an error.
+type errorSink struct {
+	err   error
+	calls int
+}
+
+func (e *errorSink) Receive(_ events.ResourceType, _ events.Operation, _ uuid.UUID, _ ...any) error {
+	e.calls++
+	return e.err
+}

--- a/pkg/eventfilter/eventfilter_suite_test.go
+++ b/pkg/eventfilter/eventfilter_suite_test.go
@@ -1,0 +1,13 @@
+package eventfilter_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEventfilter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pkg/eventfilter Suite")
+}

--- a/pkg/eventfilter/filter.go
+++ b/pkg/eventfilter/filter.go
@@ -1,0 +1,43 @@
+package eventfilter
+
+import (
+	"github.com/google/uuid"
+	"go.emeland.io/modelsrv/pkg/events"
+	"go.emeland.io/modelsrv/pkg/model"
+)
+
+// FilterID uniquely identifies a registered FilterFunc in a Chain.
+type FilterID uuid.UUID
+
+// FilterFunc is the function type every filter step must satisfy.
+// It receives the current model state and one incoming event,
+// and returns 0 or more outgoing events.
+//
+// A FilterFunc may:
+//   - pass the event through unchanged: return []events.Event{ev}
+//   - suppress the event:              return nil (or an empty slice)
+//   - expand into multiple events:     return []events.Event{ev, finding, ...}
+type FilterFunc func(m model.Model, ev events.Event) []events.Event
+
+// Chain manages an ordered list of [FilterFunc]s and executes them
+// against incoming events in registration order.
+type Chain interface {
+	// Register appends fn to the chain and returns a FilterID that can
+	// be passed to Unregister to remove it later.
+	Register(fn FilterFunc) FilterID
+
+	// Unregister removes the filter identified by id from the chain.
+	// It is a no-op if id was never registered or was already removed.
+	Unregister(id FilterID)
+
+	// Apply runs ev through every registered FilterFunc in order,
+	// flat-mapping the outputs so that one incoming event may produce
+	// 0, 1, or many outgoing events.
+	Apply(ev events.Event) []events.Event
+
+	// SetModel replaces the model reference passed to every FilterFunc.
+	// It is safe to call concurrently with Apply and is intended for
+	// breaking the construction cycle: create the Chain with nil, wrap the
+	// sink, create the Model, then call SetModel.
+	SetModel(m model.Model)
+}

--- a/pkg/eventfilter/sink.go
+++ b/pkg/eventfilter/sink.go
@@ -1,0 +1,43 @@
+package eventfilter
+
+import (
+	"github.com/google/uuid"
+	"go.emeland.io/modelsrv/pkg/events"
+)
+
+type filteringSink struct {
+	chain      Chain
+	downstream events.EventSink
+}
+
+var _ events.EventSink = (*filteringSink)(nil)
+
+// NewFilteringSink wraps downstream with a filtering layer.
+//
+// On each Receive call the event is passed through chain.Apply; every
+// event returned by the chain is forwarded to downstream in order.
+//
+// With an empty chain (no filters registered), Apply returns the
+// original event unchanged, making this a pure passthrough.
+func NewFilteringSink(chain Chain, downstream events.EventSink) events.EventSink {
+	return &filteringSink{
+		chain:      chain,
+		downstream: downstream,
+	}
+}
+
+// Receive implements [events.EventSink].
+func (s *filteringSink) Receive(resType events.ResourceType, op events.Operation, resourceId uuid.UUID, object ...any) error {
+	ev := events.Event{
+		ResourceType: resType,
+		Operation:    op,
+		ResourceId:   resourceId,
+		Objects:      object,
+	}
+	for _, out := range s.chain.Apply(ev) {
+		if err := s.downstream.Receive(out.ResourceType, out.Operation, out.ResourceId, out.Objects...); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Add pkg/eventfilter with a FilterFunc type, a Chain interface (Register/Unregister/Apply/SetModel), a thread-safe chainData implementation, and a FilteringSink adapter that intercepts model mutations and flat-maps them through the chain before forwarding to the downstream EventSink.

Add pkg/backend with a Backend type that owns the full construction cycle: EventManager → recording sink → Chain (nil model) → FilteringSink → Model → chain.SetModel. This breaks the construction cycle and gives sensors a single entry point to access the model, the filter chain, and the event manager.

Simplify cmd/modelsrv/server.go to use backend.New() in place of the manual three-step wiring.