### PR TITLE
feat: add event history endpoint

### DIFF
--- a/internal/events/manager.go
+++ b/internal/events/manager.go
@@ -16,8 +16,9 @@ type eventManager struct {
 	subscribers    []events.Subscriber
 	sinkFactory    func() (events.EventSink, error)
 
-	masterList *events.ListSink
-	modelSink  events.EventSink
+	masterList   *events.ListSink
+	storedEvents []events.StoredEvent
+	modelSink    events.EventSink
 }
 
 func NewEventManager() (events.EventManager, error) {
@@ -109,4 +110,42 @@ func (e *eventManager) RemoveSubscriber(url string) error {
 		}
 	}
 	return fmt.Errorf("subscriber %s not found", url)
+}
+
+func (e *eventManager) QueryEvents(ctx context.Context, q events.EventQuery) ([]events.StoredEvent, error) {
+	// NOTE: storedEvents only grows via append under write lock. Capturing the slice header
+	// under RLock freezes the length we iterate over; concurrent appends are safe.
+	e.mu.RLock()
+	all := e.storedEvents // TODO: add a cap/eviction strategy for production use
+	e.mu.RUnlock()
+
+	limit := q.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+
+	var results []events.StoredEvent
+	for _, ev := range all {
+		if ev.SequenceId <= q.SinceSeq {
+			continue
+		}
+		if q.Operation != nil && ev.Operation != q.Operation.WireOperation() {
+			continue
+		}
+		if q.ResourceType != nil && ev.ResourceType != q.ResourceType.WireKind() {
+			continue
+		}
+		if q.ResourceId != nil && ev.ResourceId != *q.ResourceId {
+			continue
+		}
+		entry := ev
+		if !q.IncludePayload {
+			entry.Objects = nil
+		}
+		results = append(results, entry)
+		if len(results) >= limit {
+			break
+		}
+	}
+	return results, nil
 }

--- a/internal/events/query_events_test.go
+++ b/internal/events/query_events_test.go
@@ -1,0 +1,84 @@
+package eventmgr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.emeland.io/modelsrv/pkg/events"
+)
+
+func TestQueryEvents(t *testing.T) {
+	mgr, err := NewEventManager()
+	require.NoError(t, err)
+
+	sink, err := mgr.GetSink()
+	require.NoError(t, err)
+
+	id1 := uuid.New()
+	id2 := uuid.New()
+	require.NoError(t, sink.Receive(events.SystemResource, events.CreateOperation, id1))
+	require.NoError(t, sink.Receive(events.NodeResource, events.CreateOperation, id2))
+	require.NoError(t, sink.Receive(events.SystemResource, events.DeleteOperation, id1))
+
+	ctx := context.Background()
+
+	t.Run("no filters returns all", func(t *testing.T) {
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{})
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+		assert.Equal(t, "System", results[0].ResourceType)
+		assert.Equal(t, "Create", results[0].Operation)
+	})
+
+	t.Run("filter by operation", func(t *testing.T) {
+		op := events.DeleteOperation
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{Operation: &op})
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "Delete", results[0].Operation)
+	})
+
+	t.Run("filter by resourceType", func(t *testing.T) {
+		rt := events.NodeResource
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{ResourceType: &rt})
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, id2, results[0].ResourceId)
+	})
+
+	t.Run("filter by resourceId", func(t *testing.T) {
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{ResourceId: &id1})
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("pagination with sinceSeq", func(t *testing.T) {
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{SinceSeq: 2})
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, uint64(3), results[0].SequenceId)
+	})
+
+	t.Run("limit", func(t *testing.T) {
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{Limit: 1})
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+	})
+
+	t.Run("payload excluded by default", func(t *testing.T) {
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{})
+		require.NoError(t, err)
+		assert.Nil(t, results[0].Objects)
+	})
+
+	t.Run("payload included when requested", func(t *testing.T) {
+		require.NoError(t, sink.Receive(events.SystemResource, events.CreateOperation, uuid.New(), "payload"))
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{IncludePayload: true, SinceSeq: 3})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.NotNil(t, results[0].Objects)
+	})
+}

--- a/internal/events/recording_sink.go
+++ b/internal/events/recording_sink.go
@@ -3,6 +3,7 @@ package eventmgr
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"go.emeland.io/modelsrv/pkg/events"
@@ -30,6 +31,9 @@ func (r *recordingSink) Receive(resType events.ResourceType, op events.Operation
 	r.mgr.mu.Lock()
 	_ = r.mgr.masterList.Receive(resType, op, resourceId, objects...)
 	r.mgr.sequenceNumber++
+	r.mgr.storedEvents = append(r.mgr.storedEvents, events.NewStoredEvent(
+		r.mgr.sequenceNumber, time.Now(), resType, op, resourceId, objects,
+	))
 	subs := make([]events.Subscriber, len(r.mgr.subscribers))
 	copy(subs, r.mgr.subscribers)
 	r.mgr.mu.Unlock()

--- a/internal/oapi/server_events_history.go
+++ b/internal/oapi/server_events_history.go
@@ -1,0 +1,76 @@
+package oapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
+	"go.emeland.io/modelsrv/pkg/events"
+)
+
+// HandleGetEventsHistory handles GET /api/events/history with query params for filtering/pagination.
+func (a *ApiServer) HandleGetEventsHistory(w http.ResponseWriter, r *http.Request) {
+	q := events.EventQuery{}
+
+	if v := r.URL.Query().Get("operation"); v != "" {
+		op := events.ParseWireOperation(v)
+		if op == events.UnknownOperation {
+			http.Error(w, "invalid operation filter", http.StatusBadRequest)
+			return
+		}
+		q.Operation = &op
+	}
+
+	if v := r.URL.Query().Get("resourceType"); v != "" {
+		rt := events.ParseWireKind(v)
+		if rt == events.UnknownResourceType {
+			http.Error(w, "invalid resourceType filter", http.StatusBadRequest)
+			return
+		}
+		q.ResourceType = &rt
+	}
+
+	if v := r.URL.Query().Get("resourceId"); v != "" {
+		id, err := uuid.Parse(v)
+		if err != nil {
+			http.Error(w, "invalid resourceId", http.StatusBadRequest)
+			return
+		}
+		q.ResourceId = &id
+	}
+
+	if v := r.URL.Query().Get("sinceSeq"); v != "" {
+		seq, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			http.Error(w, "invalid sinceSeq", http.StatusBadRequest)
+			return
+		}
+		q.SinceSeq = seq
+	}
+
+	if v := r.URL.Query().Get("limit"); v != "" {
+		lim, err := strconv.Atoi(v)
+		if err != nil || lim < 1 {
+			http.Error(w, "invalid limit", http.StatusBadRequest)
+			return
+		}
+		q.Limit = lim
+	}
+
+	if r.URL.Query().Get("includePayload") == "true" {
+		q.IncludePayload = true
+	}
+
+	results, err := a.Events.QueryEvents(r.Context(), q)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if results == nil {
+		results = []events.StoredEvent{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(results)
+}

--- a/pkg/endpoint/web_endpoint.go
+++ b/pkg/endpoint/web_endpoint.go
@@ -61,6 +61,9 @@ func StartWebListener(backend model.Model, eventMgr events.EventManager, addr st
 	spa := spaHandler{staticPath: "/", indexPath: "/swagger/index.html"}
 	r.PathPrefix("/swagger").Handler(spa)
 
+	// Manual endpoint: event history query
+	r.HandleFunc("/api/events/history", server.HandleGetEventsHistory).Methods("GET")
+
 	// get an `http.Handler` that we can use
 	h := oapi.HandlerFromMuxWithBaseURL(strict, r, "/api")
 

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -36,6 +36,8 @@ type Subscriber interface {
 
 // EventManager manages event sequence IDs and event sinks.
 type EventManager interface {
+	EventQuerier
+
 	// GetCurrentEventSequenceId returns the current event sequence ID as a string.
 	GetCurrentSequenceId(ctx context.Context) (uint64, error)
 	IncrementSequenceId(ctx context.Context) error

--- a/pkg/events/history.go
+++ b/pkg/events/history.go
@@ -1,0 +1,45 @@
+package events
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// StoredEvent is an event enriched with sequence ID and timestamp for history queries.
+type StoredEvent struct {
+	SequenceId   uint64    `json:"sequenceId"`
+	Timestamp    time.Time `json:"timestamp"`
+	ResourceType string    `json:"resourceType"`
+	Operation    string    `json:"operation"`
+	ResourceId   uuid.UUID `json:"resourceId"`
+	Objects      []any     `json:"objects,omitempty"`
+}
+
+// NewStoredEvent creates a StoredEvent with human-readable type/operation strings.
+func NewStoredEvent(seq uint64, ts time.Time, rt ResourceType, op Operation, id uuid.UUID, objects []any) StoredEvent {
+	return StoredEvent{
+		SequenceId:   seq,
+		Timestamp:    ts,
+		ResourceType: rt.WireKind(),
+		Operation:    op.WireOperation(),
+		ResourceId:   id,
+		Objects:      objects,
+	}
+}
+
+// EventQuery defines filters and pagination for querying event history.
+type EventQuery struct {
+	Operation      *Operation
+	ResourceType   *ResourceType
+	ResourceId     *uuid.UUID
+	SinceSeq       uint64 // return events with SequenceId > SinceSeq
+	Limit          int    // max results; 0 means default (100)
+	IncludePayload bool
+}
+
+// EventQuerier can query stored event history.
+type EventQuerier interface {
+	QueryEvents(ctx context.Context, q EventQuery) ([]StoredEvent, error)
+}


### PR DESCRIPTION
Closes #76

Adds `GET /api/events/history` — a paginated, filterable endpoint for querying the server's event history.

## Query parameters
- `operation` — Create, Update, Delete
- `resourceType` — System, Node, etc.
- `resourceId` — specific resource UUID
- `sinceSeq` — cursor-based pagination (events after this sequence ID)
- `limit` — page size (default 100)
- `includePayload` — include event objects in response (default false)

## Changes
- `pkg/events/history.go`: StoredEvent, EventQuery, EventQuerier interface
- `pkg/events/events.go`: embed EventQuerier in EventManager
- `internal/events/manager.go`: QueryEvents implementation
- `internal/events/recording_sink.go`: store enriched events with seq+timestamp
- `internal/events/query_events_test.go`: unit tests for filtering/pagination
- `internal/oapi/server_events_history.go`: HTTP handler
- `pkg/endpoint/web_endpoint.go`: route registration