### PR TITLE
(1/4) feature-17(client): preserve Reference on InstanceListItem list responses

### DIFF
--- a/cmd/emelandctl/get.go
+++ b/cmd/emelandctl/get.go
@@ -22,7 +22,26 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.emeland.io/modelsrv/pkg/client"
+	"go.emeland.io/modelsrv/pkg/model/common"
 )
+
+func renderInstanceList(cmd *cobra.Command, format string, items []common.InstanceListItem) error {
+	if format == "json" {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(items)
+	}
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(w, "ID\tNAME\tREFERENCE"); err != nil {
+		return err
+	}
+	for _, item := range items {
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\n", item.Id, item.Name, item.Reference); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
 
 func newGetCmd() *cobra.Command {
 	var outputFormat string
@@ -48,31 +67,7 @@ func newGetCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("fetching findings: %w", err)
 			}
-			if outputFormat == "json" {
-				enc := json.NewEncoder(cmd.OutOrStdout())
-				enc.SetIndent("", "  ")
-				return enc.Encode(findings)
-			}
-			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-			if _, err := fmt.Fprintln(w, "ID\tNAME\tREFERENCE"); err != nil {
-				return err
-			}
-			for _, f := range *findings {
-				id, name, ref := "", "", ""
-				if f.InstanceId != nil {
-					id = f.InstanceId.String()
-				}
-				if f.DisplayName != nil {
-					name = *f.DisplayName
-				}
-				if f.Reference != nil {
-					ref = *f.Reference
-				}
-				if _, err := fmt.Fprintf(w, "%s\t%s\t%s\n", id, name, ref); err != nil {
-					return err
-				}
-			}
-			return w.Flush()
+			return renderInstanceList(cmd, outputFormat, findings)
 		},
 	}
 

--- a/cmd/emelandctl/get_test.go
+++ b/cmd/emelandctl/get_test.go
@@ -53,6 +53,7 @@ func TestGetFindingsTable(t *testing.T) {
 	assert.Contains(t, out, "ID")
 	assert.Contains(t, out, "NAME")
 	assert.Contains(t, out, "REFERENCE")
+	assert.Contains(t, out, "/landscape/findings/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 	assert.Contains(t, out, "Missing TLS")
 	assert.Contains(t, out, "Open Port")
 	assert.Contains(t, out, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
@@ -68,10 +69,13 @@ func TestGetFindingsJSON(t *testing.T) {
 	out, err := executeCmdOut("get", "findings", "--server", srv.URL, "-o", "json")
 	require.NoError(t, err)
 
-	var items []map[string]interface{}
+	var items []struct {
+		Id   string `json:"Id"`
+		Name string `json:"Name"`
+	}
 	require.NoError(t, json.Unmarshal([]byte(out), &items))
 	assert.Len(t, items, 1)
-	assert.Equal(t, "Missing TLS", items[0]["displayName"])
+	assert.Equal(t, "Missing TLS", items[0].Name)
 }
 
 func TestGetFindingsEmpty(t *testing.T) {

--- a/internal/oapi/convert_instance_list.go
+++ b/internal/oapi/convert_instance_list.go
@@ -1,0 +1,31 @@
+package oapi
+
+import (
+	"github.com/google/uuid"
+	"go.emeland.io/modelsrv/pkg/model/common"
+)
+
+// InstanceListFromDto maps wire list items into public [common.InstanceListItem] values.
+func InstanceListFromDto(list *InstanceList) ([]common.InstanceListItem, error) {
+	if list == nil {
+		return nil, nil
+	}
+	out := make([]common.InstanceListItem, 0, len(*list))
+	for i := range *list {
+		it := (*list)[i]
+		var id uuid.UUID
+		var name string
+		var reference string
+		if it.InstanceId != nil {
+			id = uuid.UUID(*it.InstanceId)
+		}
+		if it.DisplayName != nil {
+			name = *it.DisplayName
+		}
+		if it.Reference != nil {
+			reference = *it.Reference
+		}
+		out = append(out, common.InstanceListItem{Id: id, Name: name, Reference: reference})
+	}
+	return out, nil
+}

--- a/pkg/model/common/resource_ref.go
+++ b/pkg/model/common/resource_ref.go
@@ -9,3 +9,10 @@ type ResourceRef struct {
 	ResourceId   uuid.UUID
 	ResourceType events.ResourceType
 }
+
+// InstanceListItem is a lightweight id/name/reference triple returned by client list methods.
+type InstanceListItem struct {
+	Id        uuid.UUID
+	Name      string
+	Reference string
+}


### PR DESCRIPTION
See the main issue #17 

closes #80 

Extend the public list DTO with Reference, map it in InstanceListFromDto, and show ID/NAME/REFERENCE in emelandctl get findings (table + tests).