### PR TITLE
fix(cli): dynamically generate get subcommands for all resource types

### DIFF
--- a/cmd/emelandctl/get.go
+++ b/cmd/emelandctl/get.go
@@ -50,7 +50,7 @@ func fetchResourceList(baseURL, path string) ([]common.InstanceListItem, error) 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("expected HTTP 200 but received %d", resp.StatusCode)
 	}

--- a/cmd/emelandctl/get.go
+++ b/cmd/emelandctl/get.go
@@ -18,10 +18,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"text/tabwriter"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"go.emeland.io/modelsrv/pkg/client"
 	"go.emeland.io/modelsrv/pkg/model/common"
 )
 
@@ -43,36 +45,78 @@ func renderInstanceList(cmd *cobra.Command, format string, items []common.Instan
 	return w.Flush()
 }
 
-func newGetCmd() *cobra.Command {
-	var outputFormat string
+func fetchResourceList(baseURL, path string) ([]common.InstanceListItem, error) {
+	resp, err := http.Get(baseURL + path)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expected HTTP 200 but received %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var raw []struct {
+		InstanceId  *string `json:"instanceId"`
+		DisplayName *string `json:"displayName"`
+		Reference   *string `json:"reference"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	items := make([]common.InstanceListItem, 0, len(raw))
+	for _, r := range raw {
+		var item common.InstanceListItem
+		if r.InstanceId != nil {
+			item.Id, _ = uuid.Parse(*r.InstanceId)
+		}
+		if r.DisplayName != nil {
+			item.Name = *r.DisplayName
+		}
+		if r.Reference != nil {
+			item.Reference = *r.Reference
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
 
+func newGetCmd() *cobra.Command {
 	getCmd := &cobra.Command{
 		Use:   "get",
 		Short: "Query resources from an EmELand server",
 	}
 
-	findingsCmd := &cobra.Command{
-		Use:   "findings",
-		Short: "List findings from the EmELand server",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			url, err := serverURL()
-			if err != nil {
-				return err
-			}
-			c, err := client.NewModelSrvClient(url)
-			if err != nil {
-				return fmt.Errorf("creating client: %w", err)
-			}
-			findings, err := c.GetFindings()
-			if err != nil {
-				return fmt.Errorf("fetching findings: %w", err)
-			}
-			return renderInstanceList(cmd, outputFormat, findings)
-		},
+	for _, def := range resourceTypes {
+		if def.listPath == "" {
+			continue
+		}
+		def := def // capture loop variable
+		plural := def.use + "s"
+		if def.use == "identity" {
+			plural = "identities"
+		}
+		cmd := &cobra.Command{
+			Use:   plural,
+			Short: fmt.Sprintf("List %s from the EmELand server", plural),
+			RunE: func(cmd *cobra.Command, args []string) error {
+				outputFormat, _ := cmd.Flags().GetString("output")
+				url, err := serverURL()
+				if err != nil {
+					return err
+				}
+				items, err := fetchResourceList(url, def.listPath)
+				if err != nil {
+					return fmt.Errorf("fetching %s: %w", plural, err)
+				}
+				return renderInstanceList(cmd, outputFormat, items)
+			},
+		}
+		cmd.Flags().StringP("output", "o", "table", "Output format: table or json")
+		getCmd.AddCommand(cmd)
 	}
-
-	findingsCmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "Output format: table or json")
-	getCmd.AddCommand(findingsCmd)
 
 	return getCmd
 }

--- a/cmd/emelandctl/resource.go
+++ b/cmd/emelandctl/resource.go
@@ -52,6 +52,7 @@ type resourceDef struct {
 	idField   string // spec key for the generated UUID (e.g. "systemId")
 	nameField string // spec key for the display name (default "displayName")
 	flags     []flagDef
+	listPath  string // API path for listing resources (e.g. "/landscape/findings")
 }
 
 // registerResourceCmd creates and registers a cobra subcommand from a resourceDef.

--- a/cmd/emelandctl/resource_types.go
+++ b/cmd/emelandctl/resource_types.go
@@ -20,7 +20,7 @@ package main
 var resourceTypes = []resourceDef{
 	{
 		use: "system", short: "Create a System resource",
-		kind: "System", idField: "systemId",
+		kind: "System", idField: "systemId", listPath: "/landscape/systems",
 		flags: []flagDef{
 			{name: "desc", specKey: "description", usage: "Description of the system"},
 			{name: "abstract", specKey: "abstract", usage: "Whether the system is abstract", isBool: true},
@@ -29,7 +29,7 @@ var resourceTypes = []resourceDef{
 	},
 	{
 		use: "api", short: "Create an API resource",
-		kind: "API", idField: "apiId",
+		kind: "API", idField: "apiId", listPath: "/landscape/apis",
 		flags: []flagDef{
 			{name: "desc", specKey: "description", usage: "Description of the API"},
 			{name: "type", specKey: "type", usage: "API type (OpenAPI, GraphQL, GRPC, Other)"},
@@ -38,7 +38,7 @@ var resourceTypes = []resourceDef{
 	},
 	{
 		use: "component", short: "Create a Component resource",
-		kind: "Component", idField: "componentId",
+		kind: "Component", idField: "componentId", listPath: "/landscape/components",
 		flags: []flagDef{
 			{name: "desc", specKey: "description", usage: "Description of the component"},
 			{name: "system", specKey: "system", usage: "System UUID this component belongs to"},
@@ -46,7 +46,7 @@ var resourceTypes = []resourceDef{
 	},
 	{
 		use: "context", short: "Create a Context resource",
-		kind: "Context", idField: "contextId",
+		kind: "Context", idField: "contextId", listPath: "/landscape/contexts",
 		flags: []flagDef{
 			{name: "desc", specKey: "description", usage: "Description of the context"},
 			{name: "parent", specKey: "parent", usage: "Parent context UUID"},
@@ -55,14 +55,14 @@ var resourceTypes = []resourceDef{
 	},
 	{
 		use: "context-type", short: "Create a ContextType resource",
-		kind: "ContextType", idField: "contextTypeId",
+		kind: "ContextType", idField: "contextTypeId", listPath: "/landscape/contextTypes",
 		flags: []flagDef{
 			{name: "desc", specKey: "description", usage: "Description of the context type"},
 		},
 	},
 	{
 		use: "node", short: "Create a Node resource",
-		kind: "Node", idField: "nodeId",
+		kind: "Node", idField: "nodeId", listPath: "/landscape/nodes",
 		flags: []flagDef{
 			{name: "desc", specKey: "description", usage: "Description of the node"},
 			{name: "node-type", specKey: "nodeType", usage: "Node type UUID"},
@@ -70,28 +70,28 @@ var resourceTypes = []resourceDef{
 	},
 	{
 		use: "node-type", short: "Create a NodeType resource",
-		kind: "NodeType", idField: "nodeTypeId",
+		kind: "NodeType", idField: "nodeTypeId", listPath: "/landscape/nodeTypes",
 		flags: []flagDef{
 			{name: "desc", specKey: "description", usage: "Description of the node type"},
 		},
 	},
 	{
 		use: "finding", short: "Create a Finding resource",
-		kind: "Finding", idField: "findingId", nameField: "summary",
+		kind: "Finding", idField: "findingId", nameField: "summary", listPath: "/landscape/findings",
 		flags: []flagDef{
 			{name: "desc", specKey: "description", usage: "Description of the finding"},
 		},
 	},
 	{
 		use: "finding-type", short: "Create a FindingType resource",
-		kind: "FindingType", idField: "findingTypeId",
+		kind: "FindingType", idField: "findingTypeId", listPath: "/landscape/findingTypes",
 		flags: []flagDef{
 			{name: "desc", specKey: "description", usage: "Description of the finding type"},
 		},
 	},
 	{
 		use: "system-instance", short: "Create a SystemInstance resource",
-		kind: "SystemInstance", idField: "instanceId",
+		kind: "SystemInstance", idField: "instanceId", listPath: "/landscape/system-instances",
 		flags: []flagDef{
 			{name: "system", specKey: "system", usage: "System UUID this instance refers to"},
 			{name: "context", specKey: "context", usage: "Context UUID for this instance"},
@@ -99,7 +99,7 @@ var resourceTypes = []resourceDef{
 	},
 	{
 		use: "component-instance", short: "Create a ComponentInstance resource",
-		kind: "ComponentInstance", idField: "instanceId",
+		kind: "ComponentInstance", idField: "instanceId", listPath: "/landscape/component-instances",
 		flags: []flagDef{
 			{name: "component", specKey: "component", usage: "Component UUID this instance refers to"},
 			{name: "system-instance", specKey: "systemInstance", usage: "SystemInstance UUID"},
@@ -107,7 +107,7 @@ var resourceTypes = []resourceDef{
 	},
 	{
 		use: "api-instance", short: "Create an ApiInstance resource",
-		kind: "ApiInstance", idField: "instanceId",
+		kind: "ApiInstance", idField: "instanceId", listPath: "/landscape/api-instances",
 		flags: []flagDef{
 			{name: "api", specKey: "api", usage: "API UUID this instance refers to"},
 			{name: "system-instance", specKey: "systemInstance", usage: "SystemInstance UUID"},
@@ -115,10 +115,81 @@ var resourceTypes = []resourceDef{
 	},
 	{
 		use: "product", short: "Create a Product resource",
-		kind: "Product", idField: "productId",
+		kind: "Product", idField: "productId", listPath: "/landscape/products",
 		flags: []flagDef{
 			{name: "desc", specKey: "description", usage: "Description of the product"},
 			{name: "vendor", specKey: "vendor", usage: "Vendor org unit UUID"},
+		},
+	},
+	{
+		use: "artifact", short: "Create an Artifact resource",
+		kind: "Artifact", idField: "artifactId", listPath: "/landscape/artifacts",
+		flags: []flagDef{
+			{name: "desc", specKey: "description", usage: "Description of the artifact"},
+		},
+	},
+	{
+		use: "artifact-instance", short: "Create an ArtifactInstance resource",
+		kind: "ArtifactInstance", idField: "artifactInstanceId", listPath: "/landscape/artifactInstances",
+		flags: []flagDef{
+			{name: "artifact", specKey: "artifact", usage: "Artifact UUID this instance refers to"},
+		},
+	},
+	{
+		use: "org-unit", short: "Create an OrgUnit resource",
+		kind: "OrgUnit", idField: "orgUnitId", listPath: "/landscape/orgUnits",
+		flags: []flagDef{
+			{name: "desc", specKey: "description", usage: "Description of the org unit"},
+			{name: "parent", specKey: "parent", usage: "Parent org unit UUID"},
+		},
+	},
+	{
+		use: "group", short: "Create a Group resource",
+		kind: "Group", idField: "groupId", listPath: "/landscape/groups",
+		flags: []flagDef{
+			{name: "desc", specKey: "description", usage: "Description of the group"},
+		},
+	},
+	{
+		use: "identity", short: "Create an Identity resource",
+		kind: "Identity", idField: "identityId", listPath: "/landscape/identities",
+		flags: []flagDef{
+			{name: "desc", specKey: "description", usage: "Description of the identity"},
+		},
+	},
+	{
+		use: "permission-spec", short: "Create a PermissionSpec resource",
+		kind: "PermissionSpec", idField: "permissionSpecId", listPath: "/landscape/permissionSpecs",
+		flags: []flagDef{
+			{name: "desc", specKey: "description", usage: "Description of the permission spec"},
+		},
+	},
+	{
+		use: "role-spec", short: "Create a RoleSpec resource",
+		kind: "RoleSpec", idField: "roleSpecId", listPath: "/landscape/roleSpecs",
+		flags: []flagDef{
+			{name: "desc", specKey: "description", usage: "Description of the role spec"},
+		},
+	},
+	{
+		use: "permission", short: "Create a Permission resource",
+		kind: "Permission", idField: "permissionId", listPath: "/landscape/permissions",
+		flags: []flagDef{
+			{name: "desc", specKey: "description", usage: "Description of the permission"},
+		},
+	},
+	{
+		use: "role", short: "Create a Role resource",
+		kind: "Role", idField: "roleId", listPath: "/landscape/roles",
+		flags: []flagDef{
+			{name: "desc", specKey: "description", usage: "Description of the role"},
+		},
+	},
+	{
+		use: "binding", short: "Create a Binding resource",
+		kind: "Binding", idField: "bindingId", listPath: "/landscape/bindings",
+		flags: []flagDef{
+			{name: "desc", specKey: "description", usage: "Description of the binding"},
 		},
 	},
 }


### PR DESCRIPTION
Resolves #99

## Changes

- `get.go`: Replaced the hardcoded `findings` subcommand with a loop over `resourceTypes`. Each type with a `listPath` gets a `get <plural>` subcommand automatically.
- `resource.go`: Added `listPath` field to `resourceDef`.
- `resource_types.go`: Added `listPath` to all existing entries and added missing resource types (artifacts, org-units, groups, identities, permission-specs, role-specs, permissions, roles, bindings, artifact-instances).

## Result

`emelandctl get` now supports all 23 resource types. Adding a new type only requires an entry in `resource_types.go` — no changes to `get.go`.

## Testing

All existing tests pass. The existing `TestGetFindings*` tests validate the new implementation against the same API contract.