### PR TITLE
build otel config generator from api-instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ go run ./cmd/modelsrv server --data-dir ./data --metrics-addr :9090
 
 ### OpenTelemetry Collector integration
 
-As an alternative (or complement) to in-process certprobe, export an OpenTelemetry Collector [`http_check`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/httpcheckreceiver) receivers fragment from the same ApiInstance target set:
+As an alternative (or complement) to in-process certprobe, export an OpenTelemetry Collector [`http_check`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/httpcheckreceiver) receivers fragment from ApiInstances on a **running** modelsrv:
 
 ```bash
 go run ./cmd/modelsrv certprobe \
-  --data-dir ./data \
+  --server http://localhost:8080/api/ \
   --otel-config-out ./http_check.yaml \
   --collection-interval 5m
 ```
 
-The command loads YAML from `--data-dir` the same way as `modelsrv server`, discovers probe URLs with the same annotation rules and host:port dedupe as the background daemon, and writes a fragment like:
+The command queries the landscape over HTTP (`--server`, default `http://localhost:8080/api/` or `MODELSRV_URL`), so resources replicated from upstream subscribers are included — not only local YAML. It discovers probe URLs with the same annotation rules and host:port dedupe as the background daemon, and writes a fragment like:
 
 ```yaml
 receivers:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,49 @@ The EmELand model server provides the example mapping of the Emerging Enterprise
 
 ## Usage
 
-TODO
+### In-process certificate probing
+
+Run the model server with certprobe enabled (default) to probe ApiInstance endpoints declared via [`emeland.io/endpoint.*` annotations](docs/endpoint-annotations.md):
+
+```bash
+go run ./cmd/modelsrv server --data-dir ./data --metrics-addr :9090
+```
+
+### OpenTelemetry Collector integration
+
+As an alternative (or complement) to in-process certprobe, export an OpenTelemetry Collector [`http_check`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/httpcheckreceiver) receivers fragment from the same ApiInstance target set:
+
+```bash
+go run ./cmd/modelsrv certprobe \
+  --data-dir ./data \
+  --otel-config-out ./http_check.yaml \
+  --collection-interval 5m
+```
+
+The command loads YAML from `--data-dir` the same way as `modelsrv server`, discovers probe URLs with the same annotation rules and host:port dedupe as the background daemon, and writes a fragment like:
+
+```yaml
+receivers:
+  http_check:
+    collection_interval: 5m
+    metrics:
+      httpcheck.tls.cert_remaining:
+        enabled: true
+    targets:
+      - method: GET
+        endpoint: https://payments.prod.eu.example.com:443/api/v1/health
+```
+
+Merge `receivers.http_check` into your full collector config (exporters and pipelines remain operator-owned). Enable TLS certificate metrics as shown; see the httpcheckreceiver docs for optional timing and validation metrics.
+
+#### Reload strategy
+
+When ApiInstances change, regenerate the fragment and reload the collector:
+
+1. **File write + SIGHUP** — rewrite `--otel-config-out` (cron or on model change), then send `SIGHUP` to the collector process so it reloads configuration from disk.
+2. **OpAMP supervisor** — when an [OpAMP](https://opentelemetry.io/docs/collector/management/) supervisor manages the collector, push the updated config through OpAMP instead of signaling the process directly.
+
+In-process certprobe (`modelsrv server --enable-certprobe`) and collector-side `httpcheck.tls.cert_remaining` are complementary: the former also writes EmELand Findings; the latter fits existing OTel pipelines.
 
 ## Contributing
 

--- a/cmd/modelsrv/certprobe.go
+++ b/cmd/modelsrv/certprobe.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.emeland.io/modelsrv/pkg/backend"
+	"go.emeland.io/modelsrv/pkg/endpointprobe"
+	"go.emeland.io/modelsrv/pkg/filesensor"
+	"go.uber.org/zap"
+)
+
+var (
+	certprobeDataDir            string
+	certprobeOtelConfigOut      string
+	certprobeCollectionInterval time.Duration
+)
+
+// certprobeCmd renders OpenTelemetry Collector http_check config from ApiInstance endpoints.
+var certprobeCmd = &cobra.Command{
+	Use:   "certprobe",
+	Short: "Export OpenTelemetry Collector http_check config from ApiInstance endpoints",
+	Long: `Load ApiInstances from --data-dir (same YAML as modelsrv server), discover probe
+URLs using the same annotation rules as the in-process certprobe daemon, and write an
+OpenTelemetry Collector receivers fragment for the http_check receiver.
+
+The output enables httpcheck.tls.cert_remaining and lists one GET target per unique
+host:port derived from emeland.io/endpoint.* annotations.`,
+	RunE: runCertprobe,
+}
+
+func init() {
+	rootCmd.AddCommand(certprobeCmd)
+
+	certprobeCmd.Flags().StringVar(&certprobeOtelConfigOut, "otel-config-out", "", "Path to write the http_check receivers YAML fragment (required)")
+	certprobeCmd.Flags().StringVar(&certprobeDataDir, "data-dir", envOrDefault("DATA_DIR", "data"), "Directory of YAML model definitions (.yaml/.yml)")
+	certprobeCmd.Flags().DurationVar(&certprobeCollectionInterval, "collection-interval", 5*time.Minute, "collection_interval written into the http_check receiver config")
+	_ = certprobeCmd.MarkFlagRequired("otel-config-out")
+}
+
+func runCertprobe(_ *cobra.Command, _ []string) error {
+	cfg := zap.NewDevelopmentConfig()
+	cfg.DisableStacktrace = true
+	log, err := cfg.Build()
+	if err != nil {
+		return fmt.Errorf("logger: %w", err)
+	}
+	defer log.Sync() //nolint:errcheck
+	logger := log.Sugar()
+
+	dataPath := certprobeDataDir
+	if !filepath.IsAbs(dataPath) {
+		if abs, err := filepath.Abs(dataPath); err == nil {
+			dataPath = abs
+		}
+	}
+
+	b, err := backend.New()
+	if err != nil {
+		return fmt.Errorf("create backend: %w", err)
+	}
+
+	if err := filesensor.LoadDir(dataPath, b.GetModel(), logger); err != nil {
+		return err
+	}
+
+	targets, err := endpointprobe.CollectTargets(context.Background(), endpointprobe.NewModelClient(b.GetModel()), logger)
+	if err != nil {
+		return fmt.Errorf("collect targets: %w", err)
+	}
+
+	out, err := endpointprobe.RenderHTTPCheckConfig(targets, certprobeCollectionInterval)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(certprobeOtelConfigOut, out, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", certprobeOtelConfigOut, err)
+	}
+
+	logger.Infow("wrote http_check config",
+		"path", certprobeOtelConfigOut,
+		"targets", len(targets),
+	)
+	return nil
+}

--- a/cmd/modelsrv/certprobe.go
+++ b/cmd/modelsrv/certprobe.go
@@ -5,17 +5,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
-	"go.emeland.io/modelsrv/pkg/backend"
+	"go.emeland.io/modelsrv/pkg/client"
 	"go.emeland.io/modelsrv/pkg/endpointprobe"
-	"go.emeland.io/modelsrv/pkg/filesensor"
 	"go.uber.org/zap"
 )
 
 var (
-	certprobeDataDir            string
+	certprobeServerURL          string
 	certprobeOtelConfigOut      string
 	certprobeCollectionInterval time.Duration
 )
@@ -24,9 +24,12 @@ var (
 var certprobeCmd = &cobra.Command{
 	Use:   "certprobe",
 	Short: "Export OpenTelemetry Collector http_check config from ApiInstance endpoints",
-	Long: `Load ApiInstances from --data-dir (same YAML as modelsrv server), discover probe
-URLs using the same annotation rules as the in-process certprobe daemon, and write an
+	Long: `Query ApiInstances from a running modelsrv (--server), discover probe URLs using
+the same annotation rules as the in-process certprobe daemon, and write an
 OpenTelemetry Collector receivers fragment for the http_check receiver.
+
+The landscape is read over HTTP so resources from upstream subscribers and other
+sensors are included — not only local file-sensor YAML.
 
 The output enables httpcheck.tls.cert_remaining and lists one GET target per unique
 host:port derived from emeland.io/endpoint.* annotations.`,
@@ -37,7 +40,7 @@ func init() {
 	rootCmd.AddCommand(certprobeCmd)
 
 	certprobeCmd.Flags().StringVar(&certprobeOtelConfigOut, "otel-config-out", "", "Path to write the http_check receivers YAML fragment (required)")
-	certprobeCmd.Flags().StringVar(&certprobeDataDir, "data-dir", envOrDefault("DATA_DIR", "data"), "Directory of YAML model definitions (.yaml/.yml)")
+	certprobeCmd.Flags().StringVarP(&certprobeServerURL, "server", "s", envOrDefault("MODELSRV_URL", "http://localhost:8080/api/"), "Running modelsrv API base URL (e.g. http://localhost:8080/api/)")
 	certprobeCmd.Flags().DurationVar(&certprobeCollectionInterval, "collection-interval", 5*time.Minute, "collection_interval written into the http_check receiver config")
 	_ = certprobeCmd.MarkFlagRequired("otel-config-out")
 }
@@ -52,23 +55,17 @@ func runCertprobe(_ *cobra.Command, _ []string) error {
 	defer log.Sync() //nolint:errcheck
 	logger := log.Sugar()
 
-	dataPath := certprobeDataDir
-	if !filepath.IsAbs(dataPath) {
-		if abs, err := filepath.Abs(dataPath); err == nil {
-			dataPath = abs
-		}
-	}
-
-	b, err := backend.New()
+	baseURL := normalizeAPIBaseURL(certprobeServerURL)
+	c, err := client.NewModelSrvClient(baseURL)
 	if err != nil {
-		return fmt.Errorf("create backend: %w", err)
+		return fmt.Errorf("create modelsrv client: %w", err)
 	}
 
-	if err := filesensor.LoadDir(dataPath, b.GetModel(), logger); err != nil {
-		return err
+	if err := c.GetTest(); err != nil {
+		return fmt.Errorf("connect to modelsrv at %s: %w", baseURL, err)
 	}
 
-	targets, err := endpointprobe.CollectTargets(context.Background(), endpointprobe.NewModelClient(b.GetModel()), logger)
+	targets, err := endpointprobe.CollectTargets(context.Background(), c, logger)
 	if err != nil {
 		return fmt.Errorf("collect targets: %w", err)
 	}
@@ -78,13 +75,29 @@ func runCertprobe(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	if dir := filepath.Dir(certprobeOtelConfigOut); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("create output directory %s: %w", dir, err)
+		}
+	}
 	if err := os.WriteFile(certprobeOtelConfigOut, out, 0644); err != nil {
 		return fmt.Errorf("write %s: %w", certprobeOtelConfigOut, err)
 	}
 
 	logger.Infow("wrote http_check config",
 		"path", certprobeOtelConfigOut,
+		"server", baseURL,
 		"targets", len(targets),
 	)
 	return nil
+}
+
+// normalizeAPIBaseURL ensures the URL ends with a single trailing slash so the
+// OpenAPI client joins paths correctly.
+func normalizeAPIBaseURL(u string) string {
+	u = strings.TrimSpace(u)
+	if u == "" {
+		return "http://localhost:8080/api/"
+	}
+	return strings.TrimRight(u, "/") + "/"
 }

--- a/docs/endpoint-annotations.md
+++ b/docs/endpoint-annotations.md
@@ -12,6 +12,7 @@ objects on the query API. Values MUST be flat UTF-8 strings — nested YAML maps
 
 - [Certificate probe tickets](certificate-probe-tickets.md) — implementation breakdown
 - [Findings](findings.md) — certificate findings (future milestone)
+- [README: OpenTelemetry Collector integration](../README.md#opentelemetry-collector-integration) — export `http_check` config via `modelsrv certprobe`
 
 ## Scope
 

--- a/pkg/endpointprobe/otelconfig.go
+++ b/pkg/endpointprobe/otelconfig.go
@@ -1,0 +1,96 @@
+package endpointprobe
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const defaultCollectionInterval = 5 * time.Minute
+
+// httpCheckTarget is one OpenTelemetry Collector http_check target entry.
+type httpCheckTarget struct {
+	Method   string `yaml:"method"`
+	Endpoint string `yaml:"endpoint"`
+}
+
+type httpCheckMetric struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type httpCheckReceiver struct {
+	CollectionInterval string                     `yaml:"collection_interval"`
+	Metrics            map[string]httpCheckMetric `yaml:"metrics"`
+	Targets            []httpCheckTarget          `yaml:"targets"`
+}
+
+type httpCheckConfig struct {
+	Receivers map[string]httpCheckReceiver `yaml:"receivers"`
+}
+
+// RenderHTTPCheckConfig builds an OpenTelemetry Collector receivers fragment for
+// the http_check receiver, with httpcheck.tls.cert_remaining enabled and one GET
+// target per ProbeTarget.URL. Targets are sorted by URL for stable output.
+// collectionInterval defaults to 5m when zero or negative.
+func RenderHTTPCheckConfig(targets []ProbeTarget, collectionInterval time.Duration) ([]byte, error) {
+	if collectionInterval <= 0 {
+		collectionInterval = defaultCollectionInterval
+	}
+
+	sorted := make([]ProbeTarget, len(targets))
+	copy(sorted, targets)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].URL < sorted[j].URL
+	})
+
+	outTargets := make([]httpCheckTarget, 0, len(sorted))
+	for _, t := range sorted {
+		outTargets = append(outTargets, httpCheckTarget{
+			Method:   "GET",
+			Endpoint: t.URL,
+		})
+	}
+
+	cfg := httpCheckConfig{
+		Receivers: map[string]httpCheckReceiver{
+			"http_check": {
+				CollectionInterval: formatCollectionInterval(collectionInterval),
+				Metrics: map[string]httpCheckMetric{
+					"httpcheck.tls.cert_remaining": {Enabled: true},
+				},
+				Targets: outTargets,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&cfg); err != nil {
+		return nil, fmt.Errorf("marshal http_check config: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("marshal http_check config: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// formatCollectionInterval prefers compact units (5m, 1h) over Go's String() (5m0s).
+func formatCollectionInterval(d time.Duration) string {
+	if d <= 0 {
+		return formatCollectionInterval(defaultCollectionInterval)
+	}
+	if d%time.Hour == 0 {
+		return fmt.Sprintf("%dh", d/time.Hour)
+	}
+	if d%time.Minute == 0 {
+		return fmt.Sprintf("%dm", d/time.Minute)
+	}
+	if d%time.Second == 0 {
+		return fmt.Sprintf("%ds", d/time.Second)
+	}
+	return d.String()
+}

--- a/pkg/endpointprobe/otelconfig_test.go
+++ b/pkg/endpointprobe/otelconfig_test.go
@@ -1,0 +1,119 @@
+package endpointprobe
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.emeland.io/modelsrv/pkg/model/api"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRenderHTTPCheckConfig_KnownAnnotations(t *testing.T) {
+	t.Parallel()
+
+	ai := api.NewApiInstance(uuid.MustParse("88888888-0000-4000-8000-000000000001"))
+	ai.GetAnnotations().Add(annProtocol, "https")
+	ai.GetAnnotations().Add(annHost, "payments.prod.eu.example.com")
+	ai.GetAnnotations().Add(annPort, "443")
+	ai.GetAnnotations().Add(annPath, "/api/v1/health")
+
+	target, ok, err := TargetFromApiInstance(ai)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	raw, err := RenderHTTPCheckConfig([]ProbeTarget{target}, 5*time.Minute)
+	require.NoError(t, err)
+
+	wantFragment := `
+receivers:
+  http_check:
+    collection_interval: 5m
+    metrics:
+      httpcheck.tls.cert_remaining:
+        enabled: true
+    targets:
+      - method: GET
+        endpoint: https://payments.prod.eu.example.com:443/api/v1/health
+`
+	assert.Equal(t, strings.TrimSpace(wantFragment)+"\n", string(raw))
+
+	var parsed httpCheckConfig
+	require.NoError(t, yaml.Unmarshal(raw, &parsed))
+	recv, ok := parsed.Receivers["http_check"]
+	require.True(t, ok)
+	assert.Equal(t, "5m", recv.CollectionInterval)
+	assert.True(t, recv.Metrics["httpcheck.tls.cert_remaining"].Enabled)
+	require.Len(t, recv.Targets, 1)
+	assert.Equal(t, "GET", recv.Targets[0].Method)
+	assert.Equal(t, "https://payments.prod.eu.example.com:443/api/v1/health", recv.Targets[0].Endpoint)
+}
+
+func TestRenderHTTPCheckConfig_EmptyTargets(t *testing.T) {
+	t.Parallel()
+
+	raw, err := RenderHTTPCheckConfig(nil, 0)
+	require.NoError(t, err)
+
+	var parsed httpCheckConfig
+	require.NoError(t, yaml.Unmarshal(raw, &parsed))
+	recv := parsed.Receivers["http_check"]
+	assert.Equal(t, "5m", recv.CollectionInterval)
+	assert.True(t, recv.Metrics["httpcheck.tls.cert_remaining"].Enabled)
+	assert.Empty(t, recv.Targets)
+	assert.Contains(t, string(raw), "targets:")
+}
+
+func TestRenderHTTPCheckConfig_SortsByURL(t *testing.T) {
+	t.Parallel()
+
+	raw, err := RenderHTTPCheckConfig([]ProbeTarget{
+		{URL: "https://z.example.com:443/"},
+		{URL: "https://a.example.com:443/"},
+	}, time.Minute)
+	require.NoError(t, err)
+
+	var parsed httpCheckConfig
+	require.NoError(t, yaml.Unmarshal(raw, &parsed))
+	require.Len(t, parsed.Receivers["http_check"].Targets, 2)
+	assert.Equal(t, "https://a.example.com:443/", parsed.Receivers["http_check"].Targets[0].Endpoint)
+	assert.Equal(t, "https://z.example.com:443/", parsed.Receivers["http_check"].Targets[1].Endpoint)
+}
+
+func TestCollectTargets_SkipAndDedupe(t *testing.T) {
+	t.Parallel()
+
+	instanceWithHost := uuid.MustParse("88888888-0000-4000-8000-000000000001")
+	instanceNoHost := uuid.MustParse("88888888-0000-4000-8000-000000000002")
+	instanceDupHost := uuid.MustParse("88888888-0000-4000-8000-000000000003")
+
+	ai1 := api.NewApiInstance(instanceWithHost)
+	ai1.GetAnnotations().Add(annProtocol, "https")
+	ai1.GetAnnotations().Add(annHost, "example.com")
+	ai1.GetAnnotations().Add(annPath, "/health")
+
+	ai2 := api.NewApiInstance(instanceNoHost)
+	ai2.GetAnnotations().Add(annProtocol, "https")
+
+	ai3 := api.NewApiInstance(instanceDupHost)
+	ai3.GetAnnotations().Add(annProtocol, "https")
+	ai3.GetAnnotations().Add(annHost, "example.com")
+	ai3.GetAnnotations().Add(annPath, "/metrics")
+
+	client := &fakeApiInstanceClient{instances: []api.ApiInstance{ai1, ai2, ai3}}
+	targets, err := CollectTargets(context.Background(), client, zap.NewNop().Sugar())
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, "https://example.com:443/health", targets[0].URL)
+
+	raw, err := RenderHTTPCheckConfig(targets, 5*time.Minute)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "endpoint: https://example.com:443/health")
+	assert.NotContains(t, string(raw), "/metrics")
+	assert.Equal(t, 1, strings.Count(string(raw), "endpoint:"))
+}

--- a/pkg/endpointprobe/scheduler.go
+++ b/pkg/endpointprobe/scheduler.go
@@ -240,46 +240,5 @@ func (s *Scheduler) runOnce(ctx context.Context) {
 }
 
 func (s *Scheduler) scan(ctx context.Context) ([]ProbeTarget, error) {
-	items, err := s.Client.GetApiInstances()
-	if err != nil {
-		return nil, err
-	}
-
-	seen := make(map[string]struct{})
-	targets := make([]ProbeTarget, 0, len(items))
-
-	for _, item := range items {
-		if ctx.Err() != nil {
-			break
-		}
-
-		ai, err := s.Client.GetApiInstanceById(item.Id)
-		if err != nil {
-			s.Logger.Warnw("failed to fetch api instance",
-				"apiInstanceId", item.Id,
-				"error", err,
-			)
-			continue
-		}
-
-		target, ok, err := TargetFromApiInstance(ai)
-		if err != nil {
-			s.Logger.Warnw("invalid endpoint annotations",
-				"apiInstanceId", item.Id,
-				"error", err,
-			)
-			continue
-		}
-		if !ok {
-			continue
-		}
-
-		if _, dup := seen[target.DedupeKey]; dup {
-			continue
-		}
-		seen[target.DedupeKey] = struct{}{}
-		targets = append(targets, target)
-	}
-
-	return targets, nil
+	return CollectTargets(ctx, s.Client, s.Logger)
 }

--- a/pkg/endpointprobe/targets.go
+++ b/pkg/endpointprobe/targets.go
@@ -1,0 +1,59 @@
+package endpointprobe
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+// CollectTargets lists ApiInstances, derives probe targets via TargetFromApiInstance,
+// and dedupes by DedupeKey (host:port, first wins). Skips instances without endpoint
+// host annotations and logs warnings for fetch/annotation errors.
+func CollectTargets(ctx context.Context, client ApiInstanceClient, log *zap.SugaredLogger) ([]ProbeTarget, error) {
+	if log == nil {
+		log = zap.NewNop().Sugar()
+	}
+
+	items, err := client.GetApiInstances()
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	targets := make([]ProbeTarget, 0, len(items))
+
+	for _, item := range items {
+		if ctx.Err() != nil {
+			break
+		}
+
+		ai, err := client.GetApiInstanceById(item.Id)
+		if err != nil {
+			log.Warnw("failed to fetch api instance",
+				"apiInstanceId", item.Id,
+				"error", err,
+			)
+			continue
+		}
+
+		target, ok, err := TargetFromApiInstance(ai)
+		if err != nil {
+			log.Warnw("invalid endpoint annotations",
+				"apiInstanceId", item.Id,
+				"error", err,
+			)
+			continue
+		}
+		if !ok {
+			continue
+		}
+
+		if _, dup := seen[target.DedupeKey]; dup {
+			continue
+		}
+		seen[target.DedupeKey] = struct{}{}
+		targets = append(targets, target)
+	}
+
+	return targets, nil
+}

--- a/pkg/filesensor/sensor.go
+++ b/pkg/filesensor/sensor.go
@@ -2,7 +2,6 @@ package filesensor
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -25,27 +24,13 @@ func Start(ctx context.Context, dir string, m model.Model, log *zap.SugaredLogge
 	go run(ctx, dir, m, log)
 }
 
-// LoadDir applies all .yaml/.yml files in dir to m once and runs phase0 reconcile.
-// Unlike Start, it does not create a watcher and returns when the scan completes.
-// It creates dir if missing. Per-document apply failures are logged and skipped;
-// a non-nil error is returned only when the directory cannot be read or created.
-func LoadDir(dir string, m model.Model, log *zap.SugaredLogger) error {
-	if log == nil {
-		log = zap.NewNop().Sugar()
-	}
+func run(ctx context.Context, dir string, m model.Model, log *zap.SugaredLogger) {
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("filesensor: create data directory: %w", err)
+		log.Errorw("filesensor: could not create data directory", "dir", dir, "error", err.Error())
+		return
 	}
-	apply := applyFileFunc(m, log)
-	if err := scanDir(dir, apply); err != nil {
-		return fmt.Errorf("filesensor: scan directory: %w", err)
-	}
-	phase0.ReconcileAll(m)
-	return nil
-}
 
-func applyFileFunc(m model.Model, log *zap.SugaredLogger) func(path string) {
-	return func(path string) {
+	apply := func(path string) {
 		res, err := ProcessFile(path, m)
 		if err != nil {
 			log.Errorw("filesensor: could not read or parse YAML file", "path", path, "error", err.Error())
@@ -60,15 +45,6 @@ func applyFileFunc(m model.Model, log *zap.SugaredLogger) func(path string) {
 			log.Errorw("filesensor: no documents applied", "path", path, "skipped", len(res.Failed))
 		}
 	}
-}
-
-func run(ctx context.Context, dir string, m model.Model, log *zap.SugaredLogger) {
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		log.Errorw("filesensor: could not create data directory", "dir", dir, "error", err.Error())
-		return
-	}
-
-	apply := applyFileFunc(m, log)
 
 	if err := scanDir(dir, apply); err != nil {
 		log.Errorw("filesensor: initial scan failed", "dir", dir, "error", err.Error())

--- a/pkg/filesensor/sensor.go
+++ b/pkg/filesensor/sensor.go
@@ -2,6 +2,7 @@ package filesensor
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -24,13 +25,27 @@ func Start(ctx context.Context, dir string, m model.Model, log *zap.SugaredLogge
 	go run(ctx, dir, m, log)
 }
 
-func run(ctx context.Context, dir string, m model.Model, log *zap.SugaredLogger) {
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		log.Errorw("filesensor: could not create data directory", "dir", dir, "error", err.Error())
-		return
+// LoadDir applies all .yaml/.yml files in dir to m once and runs phase0 reconcile.
+// Unlike Start, it does not create a watcher and returns when the scan completes.
+// It creates dir if missing. Per-document apply failures are logged and skipped;
+// a non-nil error is returned only when the directory cannot be read or created.
+func LoadDir(dir string, m model.Model, log *zap.SugaredLogger) error {
+	if log == nil {
+		log = zap.NewNop().Sugar()
 	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("filesensor: create data directory: %w", err)
+	}
+	apply := applyFileFunc(m, log)
+	if err := scanDir(dir, apply); err != nil {
+		return fmt.Errorf("filesensor: scan directory: %w", err)
+	}
+	phase0.ReconcileAll(m)
+	return nil
+}
 
-	apply := func(path string) {
+func applyFileFunc(m model.Model, log *zap.SugaredLogger) func(path string) {
+	return func(path string) {
 		res, err := ProcessFile(path, m)
 		if err != nil {
 			log.Errorw("filesensor: could not read or parse YAML file", "path", path, "error", err.Error())
@@ -45,6 +60,15 @@ func run(ctx context.Context, dir string, m model.Model, log *zap.SugaredLogger)
 			log.Errorw("filesensor: no documents applied", "path", path, "skipped", len(res.Failed))
 		}
 	}
+}
+
+func run(ctx context.Context, dir string, m model.Model, log *zap.SugaredLogger) {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		log.Errorw("filesensor: could not create data directory", "dir", dir, "error", err.Error())
+		return
+	}
+
+	apply := applyFileFunc(m, log)
 
 	if err := scanDir(dir, apply); err != nil {
 		log.Errorw("filesensor: initial scan failed", "dir", dir, "error", err.Error())


### PR DESCRIPTION
closes #133 

@michas2  @hexdmp  the changes from our meeting on friday will be implemented as well. Creating the http check yaml is still in scope, since this is the base line for #134 