### PR TITLE
certprobe: generate collector config for modelsrv-otel-exporter

### DIFF
--- a/cmd/modelsrv/certprobe.go
+++ b/cmd/modelsrv/certprobe.go
@@ -18,30 +18,39 @@ var (
 	certprobeServerURL          string
 	certprobeOtelConfigOut      string
 	certprobeCollectionInterval time.Duration
+	certprobeListenAddr         string
+	certprobeExpiryThreshold    time.Duration
+	certprobeSubscribers        []string
 )
 
-// certprobeCmd renders OpenTelemetry Collector http_check config from ApiInstance endpoints.
+// certprobeCmd generates a ready-to-run OTel Collector config for modelsrv-otel-exporter.
 var certprobeCmd = &cobra.Command{
 	Use:   "certprobe",
-	Short: "Export OpenTelemetry Collector http_check config from ApiInstance endpoints",
-	Long: `Query ApiInstances from a running modelsrv (--server), discover probe URLs using
-the same annotation rules as the in-process certprobe daemon, and write an
-OpenTelemetry Collector receivers fragment for the http_check receiver.
+	Short: "Generate OTel Collector config for modelsrv-otel-exporter",
+	Long: `Query ApiInstances from a running modelsrv (--server), discover probe URLs
+from emeland.io/endpoint.* annotations, and write a complete OTel Collector
+config for the modelsrv-otel-exporter binary.
 
-The landscape is read over HTTP so resources from upstream subscribers and other
-sensors are included — not only local file-sensor YAML.
+The generated config includes:
+- httpcheck receiver with targets derived from ApiInstance annotations
+- emeland exporter with endpoint_mapping (URL -> ApiInstance UUID)
+- service pipeline wiring them together
 
-The output enables httpcheck.tls.cert_remaining and lists one GET target per unique
-host:port derived from emeland.io/endpoint.* annotations.`,
+Usage:
+  modelsrv certprobe --otel-config-out collector.yaml --subscriber http://modelsrv:8080
+  modelsrv-otel-exporter --config collector.yaml`,
 	RunE: runCertprobe,
 }
 
 func init() {
 	rootCmd.AddCommand(certprobeCmd)
 
-	certprobeCmd.Flags().StringVar(&certprobeOtelConfigOut, "otel-config-out", "", "Path to write the http_check receivers YAML fragment (required)")
-	certprobeCmd.Flags().StringVarP(&certprobeServerURL, "server", "s", envOrDefault("MODELSRV_URL", "http://localhost:8080/api/"), "Running modelsrv API base URL (e.g. http://localhost:8080/api/)")
-	certprobeCmd.Flags().DurationVar(&certprobeCollectionInterval, "collection-interval", 5*time.Minute, "collection_interval written into the http_check receiver config")
+	certprobeCmd.Flags().StringVar(&certprobeOtelConfigOut, "otel-config-out", "", "Path to write the collector config (required)")
+	certprobeCmd.Flags().StringVarP(&certprobeServerURL, "server", "s", envOrDefault("MODELSRV_URL", "http://localhost:8080/api/"), "Running modelsrv API base URL")
+	certprobeCmd.Flags().DurationVar(&certprobeCollectionInterval, "collection-interval", 5*time.Minute, "collection_interval for the httpcheck receiver")
+	certprobeCmd.Flags().StringVar(&certprobeListenAddr, "listen-addr", "0.0.0.0:24200", "listen_addr for the emeland exporter")
+	certprobeCmd.Flags().DurationVar(&certprobeExpiryThreshold, "expiry-threshold", 30*24*time.Hour, "Expiry threshold for certificate findings")
+	certprobeCmd.Flags().StringArrayVar(&certprobeSubscribers, "subscriber", nil, "Downstream modelsrv URL to push events to (repeatable)")
 	_ = certprobeCmd.MarkFlagRequired("otel-config-out")
 }
 
@@ -70,7 +79,12 @@ func runCertprobe(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("collect targets: %w", err)
 	}
 
-	out, err := endpointprobe.RenderHTTPCheckConfig(targets, certprobeCollectionInterval)
+	out, err := endpointprobe.RenderCollectorConfig(targets, endpointprobe.CollectorConfigOptions{
+		CollectionInterval: certprobeCollectionInterval,
+		ListenAddr:         certprobeListenAddr,
+		ExpiryThreshold:    certprobeExpiryThreshold,
+		Subscribers:        certprobeSubscribers,
+	})
 	if err != nil {
 		return err
 	}
@@ -84,7 +98,7 @@ func runCertprobe(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("write %s: %w", certprobeOtelConfigOut, err)
 	}
 
-	logger.Infow("wrote http_check config",
+	logger.Infow("wrote collector config",
 		"path", certprobeOtelConfigOut,
 		"server", baseURL,
 		"targets", len(targets),

--- a/pkg/endpointprobe/otelconfig.go
+++ b/pkg/endpointprobe/otelconfig.go
@@ -27,17 +27,57 @@ type httpCheckReceiver struct {
 	Targets            []httpCheckTarget          `yaml:"targets"`
 }
 
-type httpCheckConfig struct {
-	Receivers map[string]httpCheckReceiver `yaml:"receivers"`
+// CollectorConfigOptions controls the output of [RenderCollectorConfig].
+type CollectorConfigOptions struct {
+	// CollectionInterval for the httpcheck receiver. Defaults to 5m.
+	CollectionInterval time.Duration
+	// ListenAddr for the emeland exporter's modelsrv HTTP API.
+	ListenAddr string
+	// ExpiryThreshold for certificate findings. Defaults to 720h (30 days).
+	ExpiryThreshold time.Duration
+	// Subscribers is a list of downstream modelsrv URLs.
+	Subscribers []string
 }
 
-// RenderHTTPCheckConfig builds an OpenTelemetry Collector receivers fragment for
-// the http_check receiver, with httpcheck.tls.cert_remaining enabled and one GET
-// target per ProbeTarget.URL. Targets are sorted by URL for stable output.
-// collectionInterval defaults to 5m when zero or negative.
-func RenderHTTPCheckConfig(targets []ProbeTarget, collectionInterval time.Duration) ([]byte, error) {
-	if collectionInterval <= 0 {
-		collectionInterval = defaultCollectionInterval
+// collectorConfig is the top-level OTel Collector config structure.
+type collectorConfig struct {
+	Receivers map[string]httpCheckReceiver `yaml:"receivers"`
+	Exporters map[string]emelandExporter  `yaml:"exporters"`
+	Service   collectorService            `yaml:"service"`
+}
+
+type emelandExporter struct {
+	ListenAddr      string            `yaml:"listen_addr"`
+	ExpiryThreshold string            `yaml:"expiry_threshold,omitempty"`
+	Subscribers     []string          `yaml:"subscribers,omitempty"`
+	EndpointMapping map[string]string `yaml:"endpoint_mapping"`
+}
+
+type collectorService struct {
+	Pipelines map[string]collectorPipeline `yaml:"pipelines"`
+}
+
+type collectorPipeline struct {
+	Receivers []string `yaml:"receivers"`
+	Exporters []string `yaml:"exporters"`
+}
+
+// RenderCollectorConfig builds a complete OTel Collector config for the
+// modelsrv-otel-exporter binary. It includes the httpcheck receiver, the
+// emeland exporter with endpoint_mapping, and the service pipeline.
+//
+// The output is ready to run as-is:
+//
+//	modelsrv-otel-exporter --config <output-file>
+func RenderCollectorConfig(targets []ProbeTarget, opts CollectorConfigOptions) ([]byte, error) {
+	if opts.CollectionInterval <= 0 {
+		opts.CollectionInterval = defaultCollectionInterval
+	}
+	if opts.ListenAddr == "" {
+		opts.ListenAddr = "0.0.0.0:24200"
+	}
+	if opts.ExpiryThreshold <= 0 {
+		opts.ExpiryThreshold = 30 * 24 * time.Hour
 	}
 
 	sorted := make([]ProbeTarget, len(targets))
@@ -47,21 +87,39 @@ func RenderHTTPCheckConfig(targets []ProbeTarget, collectionInterval time.Durati
 	})
 
 	outTargets := make([]httpCheckTarget, 0, len(sorted))
+	endpointMapping := make(map[string]string, len(sorted))
 	for _, t := range sorted {
 		outTargets = append(outTargets, httpCheckTarget{
 			Method:   "GET",
 			Endpoint: t.URL,
 		})
+		endpointMapping[t.URL] = t.ApiInstanceID.String()
 	}
 
-	cfg := httpCheckConfig{
+	cfg := collectorConfig{
 		Receivers: map[string]httpCheckReceiver{
-			"http_check": {
-				CollectionInterval: formatCollectionInterval(collectionInterval),
+			"httpcheck": {
+				CollectionInterval: formatCollectionInterval(opts.CollectionInterval),
 				Metrics: map[string]httpCheckMetric{
 					"httpcheck.tls.cert_remaining": {Enabled: true},
 				},
 				Targets: outTargets,
+			},
+		},
+		Exporters: map[string]emelandExporter{
+			"emeland": {
+				ListenAddr:      opts.ListenAddr,
+				ExpiryThreshold: formatExpiryThreshold(opts.ExpiryThreshold),
+				Subscribers:     opts.Subscribers,
+				EndpointMapping: endpointMapping,
+			},
+		},
+		Service: collectorService{
+			Pipelines: map[string]collectorPipeline{
+				"metrics": {
+					Receivers: []string{"httpcheck"},
+					Exporters: []string{"emeland"},
+				},
 			},
 		},
 	}
@@ -70,10 +128,10 @@ func RenderHTTPCheckConfig(targets []ProbeTarget, collectionInterval time.Durati
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)
 	if err := enc.Encode(&cfg); err != nil {
-		return nil, fmt.Errorf("marshal http_check config: %w", err)
+		return nil, fmt.Errorf("marshal collector config: %w", err)
 	}
 	if err := enc.Close(); err != nil {
-		return nil, fmt.Errorf("marshal http_check config: %w", err)
+		return nil, fmt.Errorf("marshal collector config: %w", err)
 	}
 	return buf.Bytes(), nil
 }
@@ -93,4 +151,11 @@ func formatCollectionInterval(d time.Duration) string {
 		return fmt.Sprintf("%ds", d/time.Second)
 	}
 	return d.String()
+}
+
+func formatExpiryThreshold(d time.Duration) string {
+	if d <= 0 {
+		return "720h"
+	}
+	return formatCollectionInterval(d)
 }

--- a/pkg/endpointprobe/otelconfig_test.go
+++ b/pkg/endpointprobe/otelconfig_test.go
@@ -2,7 +2,6 @@ package endpointprobe
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -14,10 +13,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestRenderHTTPCheckConfig_KnownAnnotations(t *testing.T) {
+func TestRenderCollectorConfig_KnownAnnotations(t *testing.T) {
 	t.Parallel()
 
-	ai := api.NewApiInstance(uuid.MustParse("88888888-0000-4000-8000-000000000001"))
+	apiInstanceID := uuid.MustParse("88888888-0000-4000-8000-000000000001")
+	ai := api.NewApiInstance(apiInstanceID)
 	ai.GetAnnotations().Add(annProtocol, "https")
 	ai.GetAnnotations().Add(annHost, "payments.prod.eu.example.com")
 	ai.GetAnnotations().Add(annPort, "443")
@@ -27,62 +27,73 @@ func TestRenderHTTPCheckConfig_KnownAnnotations(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	raw, err := RenderHTTPCheckConfig([]ProbeTarget{target}, 5*time.Minute)
+	raw, err := RenderCollectorConfig([]ProbeTarget{target}, CollectorConfigOptions{
+		CollectionInterval: 5 * time.Minute,
+		ListenAddr:         "0.0.0.0:24200",
+		Subscribers:        []string{"http://modelsrv:8080"},
+	})
 	require.NoError(t, err)
 
-	wantFragment := `
-receivers:
-  http_check:
-    collection_interval: 5m
-    metrics:
-      httpcheck.tls.cert_remaining:
-        enabled: true
-    targets:
-      - method: GET
-        endpoint: https://payments.prod.eu.example.com:443/api/v1/health
-`
-	assert.Equal(t, strings.TrimSpace(wantFragment)+"\n", string(raw))
+	out := string(raw)
 
-	var parsed httpCheckConfig
+	// Receiver
+	assert.Contains(t, out, "httpcheck:")
+	assert.Contains(t, out, "collection_interval: 5m")
+	assert.Contains(t, out, "endpoint: https://payments.prod.eu.example.com:443/api/v1/health")
+
+	// Exporter
+	assert.Contains(t, out, "emeland:")
+	assert.Contains(t, out, "listen_addr: 0.0.0.0:24200")
+	assert.Contains(t, out, "expiry_threshold: 720h")
+	assert.Contains(t, out, "http://modelsrv:8080")
+
+	// Endpoint mapping
+	assert.Contains(t, out, "https://payments.prod.eu.example.com:443/api/v1/health: 88888888-0000-4000-8000-000000000001")
+
+	// Service pipeline
+	assert.Contains(t, out, "pipelines:")
+
+	// Verify it's valid YAML
+	var parsed collectorConfig
 	require.NoError(t, yaml.Unmarshal(raw, &parsed))
-	recv, ok := parsed.Receivers["http_check"]
-	require.True(t, ok)
+	recv := parsed.Receivers["httpcheck"]
 	assert.Equal(t, "5m", recv.CollectionInterval)
 	assert.True(t, recv.Metrics["httpcheck.tls.cert_remaining"].Enabled)
 	require.Len(t, recv.Targets, 1)
 	assert.Equal(t, "GET", recv.Targets[0].Method)
 	assert.Equal(t, "https://payments.prod.eu.example.com:443/api/v1/health", recv.Targets[0].Endpoint)
+	assert.Equal(t, apiInstanceID.String(), parsed.Exporters["emeland"].EndpointMapping["https://payments.prod.eu.example.com:443/api/v1/health"])
 }
 
-func TestRenderHTTPCheckConfig_EmptyTargets(t *testing.T) {
+func TestRenderCollectorConfig_EmptyTargets(t *testing.T) {
 	t.Parallel()
 
-	raw, err := RenderHTTPCheckConfig(nil, 0)
+	raw, err := RenderCollectorConfig(nil, CollectorConfigOptions{})
 	require.NoError(t, err)
 
-	var parsed httpCheckConfig
+	var parsed collectorConfig
 	require.NoError(t, yaml.Unmarshal(raw, &parsed))
-	recv := parsed.Receivers["http_check"]
+	recv := parsed.Receivers["httpcheck"]
 	assert.Equal(t, "5m", recv.CollectionInterval)
 	assert.True(t, recv.Metrics["httpcheck.tls.cert_remaining"].Enabled)
 	assert.Empty(t, recv.Targets)
-	assert.Contains(t, string(raw), "targets:")
+	assert.Empty(t, parsed.Exporters["emeland"].EndpointMapping)
 }
 
-func TestRenderHTTPCheckConfig_SortsByURL(t *testing.T) {
+func TestRenderCollectorConfig_SortsByURL(t *testing.T) {
 	t.Parallel()
 
-	raw, err := RenderHTTPCheckConfig([]ProbeTarget{
-		{URL: "https://z.example.com:443/"},
-		{URL: "https://a.example.com:443/"},
-	}, time.Minute)
+	raw, err := RenderCollectorConfig([]ProbeTarget{
+		{ApiInstanceID: uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000001"), URL: "https://z.example.com:443/"},
+		{ApiInstanceID: uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000002"), URL: "https://a.example.com:443/"},
+	}, CollectorConfigOptions{CollectionInterval: time.Minute})
 	require.NoError(t, err)
 
-	var parsed httpCheckConfig
+	var parsed collectorConfig
 	require.NoError(t, yaml.Unmarshal(raw, &parsed))
-	require.Len(t, parsed.Receivers["http_check"].Targets, 2)
-	assert.Equal(t, "https://a.example.com:443/", parsed.Receivers["http_check"].Targets[0].Endpoint)
-	assert.Equal(t, "https://z.example.com:443/", parsed.Receivers["http_check"].Targets[1].Endpoint)
+	require.Len(t, parsed.Receivers["httpcheck"].Targets, 2)
+	assert.Equal(t, "https://a.example.com:443/", parsed.Receivers["httpcheck"].Targets[0].Endpoint)
+	assert.Equal(t, "https://z.example.com:443/", parsed.Receivers["httpcheck"].Targets[1].Endpoint)
 }
 
 func TestCollectTargets_SkipAndDedupe(t *testing.T) {
@@ -110,10 +121,5 @@ func TestCollectTargets_SkipAndDedupe(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, targets, 1)
 	assert.Equal(t, "https://example.com:443/health", targets[0].URL)
-
-	raw, err := RenderHTTPCheckConfig(targets, 5*time.Minute)
-	require.NoError(t, err)
-	assert.Contains(t, string(raw), "endpoint: https://example.com:443/health")
-	assert.NotContains(t, string(raw), "/metrics")
-	assert.Equal(t, 1, strings.Count(string(raw), "endpoint:"))
+	assert.Equal(t, instanceWithHost, targets[0].ApiInstanceID)
 }


### PR DESCRIPTION
The `certprobe` subcommand now generates a complete OTel Collector config for [modelsrv-otel-exporter](https://github.com/emeland-io/modelsrv-otel-exporter):

```sh
modelsrv certprobe --otel-config-out collector.yaml --subscriber http://modelsrv:8080
modelsrv-otel-exporter --config collector.yaml
```

Generated config includes:
- `httpcheck` receiver with targets from ApiInstance annotations
- `emeland` exporter with `endpoint_mapping` (URL -> ApiInstance UUID)
- Service pipeline wiring them together

Replaces the old receivers-only fragment with a ready-to-run config. Also fixes the receiver key to `httpcheck` (the actual component type).

Closes #134