### PR TITLE
Enable compacting for large set of change events.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ cover.out
 .vscode/
 bin/
 /data/*
+/test/loadscale/load_scale_report.md
 
 .gomodcache/
 .gocache/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin/
 .gopath/
 .cursor/
 .idea/
+.superpowers/

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,19 @@ gen: ## Regenerate OpenAPI server, client, and pkg/client models (same packages 
 test: generate fmt vet ## Run tests.
 	go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
+# Sorted, comma-separated lists of instance/change counts; override to customize the scan,
+# e.g. `make test-load-scale LOAD_SCALE_INSTANCE_COUNTS=10,1000,10000`.
+LOAD_SCALE_INSTANCE_COUNTS ?= 10,100,1000
+LOAD_SCALE_CHANGE_COUNTS ?= 10,100,1000
+LOAD_SCALE_REPORT_PATH ?= $(shell pwd)/test/loadscale/load_scale_report.md
+
+.PHONY: test-load-scale
+test-load-scale: ## Run the opt-in load/scale memory test (large numbers of resources & changes). Writes a markdown report to LOAD_SCALE_REPORT_PATH.
+	LOAD_SCALE_INSTANCE_COUNTS=$(LOAD_SCALE_INSTANCE_COUNTS) \
+	LOAD_SCALE_CHANGE_COUNTS=$(LOAD_SCALE_CHANGE_COUNTS) \
+	LOAD_SCALE_REPORT_PATH=$(LOAD_SCALE_REPORT_PATH) \
+	go test -tags=load_n_scale -run TestLoadScale -v -timeout 60m ./test/loadscale/...
+
 .PHONY: fmt
 fmt: ## Run go fmt against code.
 	go fmt ./...

--- a/cmd/modelsrv/server.go
+++ b/cmd/modelsrv/server.go
@@ -7,9 +7,12 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
+	eventmgr "go.emeland.io/modelsrv/internal/events"
 	"go.emeland.io/modelsrv/pkg/authz"
 	"go.emeland.io/modelsrv/pkg/backend"
 	"go.emeland.io/modelsrv/pkg/endpoint"
@@ -24,6 +27,13 @@ var trustAuthHeaders bool
 var auditorIdentity string
 var auditorGroup string
 var publicResourceTypes string
+var enableCertprobe bool
+var certprobeInterval time.Duration
+var certprobeDebounce time.Duration
+var certprobeTimeout time.Duration
+var certprobeExpiryWarning time.Duration
+var maxConcurrentProbes int
+var eventHistoryLimit int
 
 // serverCmd represents the server command
 var serverCmd = &cobra.Command{
@@ -43,7 +53,7 @@ var serverCmd = &cobra.Command{
 
 		logger := log.Sugar()
 
-		b, err := backend.New()
+		b, err := backend.New(backend.WithEventHistoryLimit(eventHistoryLimit))
 		if err != nil {
 			logger.Errorw("error creating backend", "error", err)
 			return
@@ -112,11 +122,36 @@ func init() {
 	serverCmd.Flags().StringVar(&auditorIdentity, "auditor-identity", envOrDefault("AUDITOR_IDENTITY", ""), "OIDC subject treated as auditor when matching X-Auth-Subject")
 	serverCmd.Flags().StringVar(&auditorGroup, "auditor-group", envOrDefault("AUDITOR_GROUP", ""), "Group id treated as auditor when present in X-Auth-Groups")
 	serverCmd.Flags().StringVar(&publicResourceTypes, "public-resource-types", envOrDefault("PUBLIC_RESOURCE_TYPES", ""), "Comma-separated resource types always visible (e.g. ContextType,FindingType)")
+	serverCmd.Flags().BoolVar(&enableCertprobe, "enable-certprobe", envOrDefault("ENABLE_CERTPROBE", "true") == "true", "Run certificate probing as a background process inside modelsrv")
+	serverCmd.Flags().DurationVar(&certprobeInterval, "certprobe-interval", 5*time.Minute, "Certprobe background scan interval")
+	serverCmd.Flags().DurationVar(&certprobeDebounce, "certprobe-debounce", envDurationOrDefault("CERTPROBE_DEBOUNCE", 5*time.Second), "Debounce window before event-triggered certprobe rescans")
+	serverCmd.Flags().DurationVar(&certprobeTimeout, "certprobe-timeout", 10*time.Second, "Per-probe HTTP/TLS timeout")
+	serverCmd.Flags().DurationVar(&certprobeExpiryWarning, "expiry-warning", 720*time.Hour, "Raise CertificateExpiringSoon when remaining cert lifetime is at or below this duration")
+	serverCmd.Flags().IntVar(&maxConcurrentProbes, "max-concurrent-probes", 10, "Certprobe worker pool size")
+	serverCmd.Flags().IntVar(&eventHistoryLimit, "event-history-limit", envIntOrDefault("EVENT_HISTORY_LIMIT", eventmgr.DefaultHistoryLimit), "Number of recent events the /events history API can serve exactly; older queries return synthesized current-state entries instead of an error")
 }
 
 func envOrDefault(key, fallback string) string {
 	if v, ok := os.LookupEnv(key); ok {
 		return v
+	}
+	return fallback
+}
+
+func envDurationOrDefault(key string, fallback time.Duration) time.Duration {
+	if v, ok := os.LookupEnv(key); ok {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return fallback
+}
+
+func envIntOrDefault(key string, fallback int) int {
+	if v, ok := os.LookupEnv(key); ok {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
 	}
 	return fallback
 }

--- a/docs/superpowers/plans/2026-07-27-event-store-compaction.md
+++ b/docs/superpowers/plans/2026-07-27-event-store-compaction.md
@@ -1,0 +1,992 @@
+# Event Store Compaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bound the heap used by `internal/events.eventManager`'s two in-memory event logs — one now scales with live (undeleted) resource count, the other with a configurable retention limit — instead of both growing forever with total events observed.
+
+**Architecture:** Replace `masterList` (`*events.ListSink`, unbounded) with `latestStateStore`, a compacted map keyed by `(ResourceType, ResourceId)` holding only each live resource's latest event. Replace `storedEvents` (`[]events.StoredEvent`, unbounded) with `historyRing`, a fixed-capacity ring buffer. `QueryEvents` synthesizes missing history (for resources evicted from the ring but still live) directly from `latestStateStore` at query time, so no third data structure or eviction-time bookkeeping is needed beyond a `compactionSeq`/`compactionAt` boundary marker on the ring.
+
+**Tech Stack:** Go, ginkgo/gomega (BDD tests in this package) and stdlib `testing` + testify (table-style tests in this package) — both already used side-by-side in `internal/events`.
+
+## Global Constraints
+
+- `pkg/events.ListSink` (public type) must not change — it's a full-fidelity test double used across ~30 test files and is unrelated to these two logs.
+- All existing zero-arg call sites of `eventmgr.NewEventManager()` and `backend.New()` (~15+ across tests and `cmd/modelsrv/server.go`) must keep compiling and behaving identically (default retention: 1000 events).
+- No change to `EventQuery`/`StoredEvent` wire shapes, `SequenceId` semantics, or `GetCurrentSequenceId`/`IncrementSequenceId`.
+- When total events ever observed is at or below the retention limit, `QueryEvents` output must be byte-for-byte identical to today's unbounded implementation (no synthesized entries at all).
+- Spec: `docs/superpowers/specs/2026-07-27-event-store-compaction-design.md`.
+
+---
+
+### Task 1: `latestStateStore` — compacted per-resource state
+
+**Files:**
+- Create: `internal/events/latest_state.go`
+- Test: `internal/events/latest_state_test.go`
+
+**Interfaces:**
+- Produces: `type resourceKey struct { resType events.ResourceType; id uuid.UUID }`, `type latestStateStore struct{...}`, `newLatestStateStore() *latestStateStore`, `(*latestStateStore) Receive(resType events.ResourceType, op events.Operation, resourceId uuid.UUID, objects ...any)`, `(*latestStateStore) GetEvents() []events.Event`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/events/latest_state_test.go`:
+
+```go
+package eventmgr
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.emeland.io/modelsrv/pkg/events"
+)
+
+func TestLatestStateStore_UpsertReplacesPriorState(t *testing.T) {
+	s := newLatestStateStore()
+	id := uuid.New()
+	s.Receive(events.SystemResource, events.CreateOperation, id, "v1")
+	s.Receive(events.SystemResource, events.UpdateOperation, id, "v2")
+
+	got := s.GetEvents()
+	require.Len(t, got, 1)
+	assert.Equal(t, events.CreateOperation, got[0].Operation)
+	assert.Equal(t, id, got[0].ResourceId)
+	assert.Equal(t, []any{"v2"}, got[0].Objects)
+}
+
+func TestLatestStateStore_DeleteRemovesEntry(t *testing.T) {
+	s := newLatestStateStore()
+	id := uuid.New()
+	s.Receive(events.SystemResource, events.CreateOperation, id, "v1")
+	s.Receive(events.SystemResource, events.DeleteOperation, id)
+
+	assert.Empty(t, s.GetEvents())
+}
+
+func TestLatestStateStore_DeleteUnknownIsNoop(t *testing.T) {
+	s := newLatestStateStore()
+	s.Receive(events.SystemResource, events.DeleteOperation, uuid.New())
+
+	assert.Empty(t, s.GetEvents())
+}
+
+func TestLatestStateStore_OrderPreservedAndRecreateAppendsAtEnd(t *testing.T) {
+	s := newLatestStateStore()
+	idA := uuid.New()
+	idB := uuid.New()
+	s.Receive(events.SystemResource, events.CreateOperation, idA, "a1")
+	s.Receive(events.SystemResource, events.CreateOperation, idB, "b1")
+	s.Receive(events.SystemResource, events.DeleteOperation, idA)
+	s.Receive(events.SystemResource, events.CreateOperation, idA, "a2")
+
+	got := s.GetEvents()
+	require.Len(t, got, 2)
+	assert.Equal(t, idB, got[0].ResourceId)
+	assert.Equal(t, idA, got[1].ResourceId)
+	assert.Equal(t, []any{"a2"}, got[1].Objects)
+}
+
+func TestLatestStateStore_KeyIncludesResourceType(t *testing.T) {
+	s := newLatestStateStore()
+	id := uuid.New()
+	s.Receive(events.SystemResource, events.CreateOperation, id, "sys")
+	s.Receive(events.NodeResource, events.CreateOperation, id, "node")
+
+	assert.Len(t, s.GetEvents(), 2)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/events/... -run TestLatestStateStore -v`
+Expected: FAIL with `undefined: newLatestStateStore` (the type doesn't exist yet)
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/events/latest_state.go`:
+
+```go
+package eventmgr
+
+import (
+	"github.com/google/uuid"
+	"go.emeland.io/modelsrv/pkg/events"
+)
+
+type resourceKey struct {
+	resType events.ResourceType
+	id      uuid.UUID
+}
+
+// latestStateStore keeps only the most recent event of each live resource,
+// so heap usage scales with the number of resources not yet deleted rather
+// than the total number of events ever observed. Every call site holds
+// eventManager.mu, so this type has no locking of its own.
+type latestStateStore struct {
+	order []resourceKey
+	state map[resourceKey]events.Event
+}
+
+func newLatestStateStore() *latestStateStore {
+	return &latestStateStore{state: make(map[resourceKey]events.Event)}
+}
+
+func (s *latestStateStore) Receive(resType events.ResourceType, op events.Operation, resourceId uuid.UUID, objects ...any) {
+	key := resourceKey{resType: resType, id: resourceId}
+
+	if op == events.DeleteOperation {
+		if _, ok := s.state[key]; ok {
+			delete(s.state, key)
+			s.removeFromOrder(key)
+		}
+		return
+	}
+
+	if _, exists := s.state[key]; !exists {
+		s.order = append(s.order, key)
+	}
+	s.state[key] = events.Event{
+		ResourceType: resType,
+		Operation:    op,
+		ResourceId:   resourceId,
+		Objects:      objects,
+	}
+}
+
+func (s *latestStateStore) removeFromOrder(key resourceKey) {
+	for i, k := range s.order {
+		if k == key {
+			s.order = append(s.order[:i], s.order[i+1:]...)
+			return
+		}
+	}
+}
+
+// GetEvents returns one event per live resource, oldest-creation-first,
+// always reported as a Create: to a party seeing this snapshot as their
+// first knowledge of the resource (a new subscriber, or a history query
+// reaching past the retention window), it is first appearing now.
+func (s *latestStateStore) GetEvents() []events.Event {
+	out := make([]events.Event, 0, len(s.order))
+	for _, key := range s.order {
+		ev := s.state[key]
+		ev.Operation = events.CreateOperation
+		out = append(out, ev)
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/events/... -run TestLatestStateStore -v`
+Expected: PASS (all 5 subtests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/events/latest_state.go internal/events/latest_state_test.go
+git commit -m "$(cat <<'EOF'
+Add latestStateStore: compacted per-resource event storage
+
+Keeps only the most recent event per live resource, keyed by
+(ResourceType, ResourceId), so heap usage scales with live resource
+count rather than total events observed. Not yet wired into eventManager.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: `historyRing` — fixed-capacity event ring buffer
+
+**Files:**
+- Create: `internal/events/history_ring.go`
+- Test: `internal/events/history_ring_test.go`
+
+**Interfaces:**
+- Consumes: `events.StoredEvent` (from `pkg/events/history.go`, fields `SequenceId uint64`, `Timestamp time.Time`, `ResourceType string`, `Operation string`, `ResourceId uuid.UUID`, `Objects []any`).
+- Produces: `const DefaultHistoryLimit = 1000`, `type historyRing struct{...}`, `newHistoryRing(limit int) *historyRing`, `(*historyRing) Add(ev events.StoredEvent)`, `(*historyRing) Snapshot() []events.StoredEvent`, `(*historyRing) CompactionBoundary() (uint64, time.Time)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/events/history_ring_test.go`:
+
+```go
+package eventmgr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.emeland.io/modelsrv/pkg/events"
+)
+
+func storedEvent(seq uint64) events.StoredEvent {
+	return events.StoredEvent{
+		SequenceId:   seq,
+		Timestamp:    time.Unix(int64(seq), 0),
+		ResourceType: "System",
+		Operation:    "Create",
+	}
+}
+
+func TestHistoryRing_UnderCapacityKeepsCompactionSeqZero(t *testing.T) {
+	r := newHistoryRing(3)
+	r.Add(storedEvent(1))
+	r.Add(storedEvent(2))
+
+	seq, _ := r.CompactionBoundary()
+	assert.Equal(t, uint64(0), seq)
+	assert.Equal(t, []events.StoredEvent{storedEvent(1), storedEvent(2)}, r.Snapshot())
+}
+
+func TestHistoryRing_WraparoundEvictsOldestAndTracksBoundary(t *testing.T) {
+	r := newHistoryRing(2)
+	r.Add(storedEvent(1))
+	r.Add(storedEvent(2))
+	r.Add(storedEvent(3)) // evicts seq 1
+
+	seq, at := r.CompactionBoundary()
+	assert.Equal(t, uint64(1), seq)
+	assert.Equal(t, storedEvent(1).Timestamp, at)
+	assert.Equal(t, []events.StoredEvent{storedEvent(2), storedEvent(3)}, r.Snapshot())
+}
+
+func TestHistoryRing_ContinuedWraparoundKeepsOrder(t *testing.T) {
+	r := newHistoryRing(2)
+	r.Add(storedEvent(1))
+	r.Add(storedEvent(2))
+	r.Add(storedEvent(3))
+	r.Add(storedEvent(4))
+
+	seq, _ := r.CompactionBoundary()
+	assert.Equal(t, uint64(2), seq)
+	assert.Equal(t, []events.StoredEvent{storedEvent(3), storedEvent(4)}, r.Snapshot())
+}
+
+func TestHistoryRing_DefaultsInvalidLimit(t *testing.T) {
+	r := newHistoryRing(0)
+	require.NotPanics(t, func() { r.Add(storedEvent(1)) })
+	assert.Len(t, r.Snapshot(), 1)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/events/... -run TestHistoryRing -v`
+Expected: FAIL with `undefined: newHistoryRing`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/events/history_ring.go`:
+
+```go
+package eventmgr
+
+import (
+	"time"
+
+	"go.emeland.io/modelsrv/pkg/events"
+)
+
+// DefaultHistoryLimit is the number of recent events QueryEvents can serve
+// exactly when no WithHistoryLimit option is given (see manager.go).
+// History reaching further back than this is synthesized from latestState
+// instead of stored verbatim.
+const DefaultHistoryLimit = 1000
+
+// historyRing is a fixed-capacity ring buffer of the most recent
+// StoredEvents. Its backing array is preallocated once at construction, so
+// heap usage is a fixed function of limit, independent of event volume.
+// Every call site holds eventManager.mu, so this type has no locking of its
+// own.
+type historyRing struct {
+	buf   []events.StoredEvent
+	limit int
+	next  int
+	size  int
+
+	compactionSeq uint64
+	compactionAt  time.Time
+}
+
+func newHistoryRing(limit int) *historyRing {
+	if limit <= 0 {
+		limit = DefaultHistoryLimit
+	}
+	return &historyRing{
+		buf:   make([]events.StoredEvent, limit),
+		limit: limit,
+	}
+}
+
+// Add appends ev, overwriting the oldest retained entry once the buffer is
+// full. The overwritten entry's SequenceId/Timestamp become the new
+// compaction boundary, so callers can tell how far back real events are
+// still available.
+func (r *historyRing) Add(ev events.StoredEvent) {
+	if r.size == r.limit {
+		evicted := r.buf[r.next]
+		r.compactionSeq = evicted.SequenceId
+		r.compactionAt = evicted.Timestamp
+	} else {
+		r.size++
+	}
+	r.buf[r.next] = ev
+	r.next = (r.next + 1) % r.limit
+}
+
+// Snapshot returns a copy of the retained entries, oldest to newest.
+func (r *historyRing) Snapshot() []events.StoredEvent {
+	out := make([]events.StoredEvent, r.size)
+	if r.size < r.limit {
+		copy(out, r.buf[:r.size])
+		return out
+	}
+	n := copy(out, r.buf[r.next:])
+	copy(out[n:], r.buf[:r.next])
+	return out
+}
+
+// CompactionBoundary returns the SequenceId/Timestamp of the most recently
+// evicted entry (zero value if nothing has been evicted yet).
+func (r *historyRing) CompactionBoundary() (uint64, time.Time) {
+	return r.compactionSeq, r.compactionAt
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/events/... -run TestHistoryRing -v`
+Expected: PASS (all 4 subtests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/events/history_ring.go internal/events/history_ring_test.go
+git commit -m "$(cat <<'EOF'
+Add historyRing: fixed-capacity ring buffer for recent event history
+
+Preallocated once at construction, so heap usage is a fixed function of
+the configured limit rather than growing with total events observed. Not
+yet wired into eventManager.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Wire `eventManager` to the bounded stores, with query-time compaction
+
+**Files:**
+- Modify: `internal/events/manager.go`
+- Modify: `internal/events/recording_sink.go`
+- Modify: `pkg/events/history.go:32-45` (doc comments only)
+- Test: `internal/events/query_events_test.go` (append new tests)
+
+**Interfaces:**
+- Consumes: `newLatestStateStore()`, `(*latestStateStore).Receive/.GetEvents()` (Task 1); `DefaultHistoryLimit`, `newHistoryRing(limit int)`, `(*historyRing).Add/.Snapshot/.CompactionBoundary()` (Task 2).
+- Produces: `type Option func(*eventManager)`, `func WithHistoryLimit(n int) Option`, `func NewEventManager(opts ...Option) (events.EventManager, error)` (signature change: now variadic, existing zero-arg calls keep compiling).
+
+- [ ] **Step 1: Write the failing test for compaction behavior**
+
+Append to `internal/events/query_events_test.go` (same file, same `package eventmgr`, add after the existing `TestQueryEvents` function):
+
+```go
+func TestQueryEvents_CompactionSynthesizesEvictedResourceState(t *testing.T) {
+	mgr, err := NewEventManager(WithHistoryLimit(2))
+	require.NoError(t, err)
+
+	sink, err := mgr.GetSink()
+	require.NoError(t, err)
+
+	idA := uuid.New()
+	idB := uuid.New()
+	idC := uuid.New()
+
+	require.NoError(t, sink.Receive(events.SystemResource, events.CreateOperation, idA, "a1")) // seq 1
+	require.NoError(t, sink.Receive(events.SystemResource, events.CreateOperation, idB, "b1")) // seq 2
+	require.NoError(t, sink.Receive(events.SystemResource, events.CreateOperation, idC, "c1")) // seq 3, evicts seq 1 (idA)
+
+	ctx := context.Background()
+
+	t.Run("query reaching past the retention window synthesizes a Create for the evicted resource", func(t *testing.T) {
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{IncludePayload: true})
+		require.NoError(t, err)
+		require.Len(t, results, 3)
+
+		assert.Equal(t, idA, results[0].ResourceId)
+		assert.Equal(t, "Create", results[0].Operation)
+		assert.Equal(t, []any{"a1"}, results[0].Objects)
+
+		assert.Equal(t, idB, results[1].ResourceId)
+		assert.Equal(t, uint64(2), results[1].SequenceId)
+
+		assert.Equal(t, idC, results[2].ResourceId)
+		assert.Equal(t, uint64(3), results[2].SequenceId)
+	})
+
+	t.Run("query inside the retained tail is unaffected by compaction", func(t *testing.T) {
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{SinceSeq: 2})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, idC, results[0].ResourceId)
+	})
+
+	t.Run("a resource still present in the tail is not duplicated by synthesis", func(t *testing.T) {
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{ResourceId: &idC})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, uint64(3), results[0].SequenceId)
+	})
+
+	t.Run("an evicted resource updated again reflects the newer value as its last entry", func(t *testing.T) {
+		require.NoError(t, sink.Receive(events.SystemResource, events.UpdateOperation, idA, "a2")) // seq 4, evicts seq 2 (idB)
+
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{ResourceId: &idA, IncludePayload: true})
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+		assert.Equal(t, []any{"a2"}, results[len(results)-1].Objects)
+	})
+
+	t.Run("under the cap, behavior is unaffected by compaction entirely", func(t *testing.T) {
+		mgr2, err := NewEventManager(WithHistoryLimit(1000))
+		require.NoError(t, err)
+		sink2, err := mgr2.GetSink()
+		require.NoError(t, err)
+		id := uuid.New()
+		require.NoError(t, sink2.Receive(events.SystemResource, events.CreateOperation, id, "only"))
+
+		results, err := mgr2.QueryEvents(ctx, events.EventQuery{IncludePayload: true})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, uint64(1), results[0].SequenceId)
+		assert.Equal(t, []any{"only"}, results[0].Objects)
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/events/... -run TestQueryEvents_CompactionSynthesizesEvictedResourceState -v`
+Expected: FAIL to compile — `WithHistoryLimit` and the new `NewEventManager` signature don't exist yet.
+
+- [ ] **Step 3: Rewrite `internal/events/manager.go`**
+
+Replace the whole file with:
+
+```go
+package eventmgr
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+	"go.emeland.io/modelsrv/pkg/events"
+)
+
+var _ events.EventManager = (*eventManager)(nil)
+
+// Option configures an eventManager at construction time.
+type Option func(*eventManager)
+
+// WithHistoryLimit sets how many recent events QueryEvents can serve
+// exactly. n must be positive or it is ignored (the default applies).
+func WithHistoryLimit(n int) Option {
+	return func(e *eventManager) {
+		if n > 0 {
+			e.historyLimit = n
+		}
+	}
+}
+
+type eventManager struct {
+	mu             sync.RWMutex
+	sequenceNumber uint64
+	subscribers    []events.Subscriber
+	sinkFactory    func() (events.EventSink, error)
+
+	latestState  *latestStateStore
+	historyTail  *historyRing
+	historyLimit int
+	modelSink    events.EventSink
+}
+
+func NewEventManager(opts ...Option) (events.EventManager, error) {
+	e := &eventManager{
+		sequenceNumber: 0,
+		subscribers:    make([]events.Subscriber, 0),
+		latestState:    newLatestStateStore(),
+		historyLimit:   DefaultHistoryLimit,
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	e.historyTail = newHistoryRing(e.historyLimit)
+	e.sinkFactory = func() (events.EventSink, error) {
+		return e.getOrCreateModelSink(), nil
+	}
+	return e, nil
+}
+
+func (e *eventManager) getOrCreateModelSink() events.EventSink {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.modelSink == nil {
+		e.modelSink = newRecordingSink(e)
+	}
+	return e.modelSink
+}
+
+func (e *eventManager) GetCurrentSequenceId(ctx context.Context) (uint64, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.sequenceNumber, nil
+}
+
+func (e *eventManager) IncrementSequenceId(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.sequenceNumber++
+	return nil
+}
+
+func (e *eventManager) SetSinkFactory(factory func() (events.EventSink, error)) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.sinkFactory = factory
+}
+
+func (e *eventManager) GetSink() (events.EventSink, error) {
+	return e.sinkFactory()
+}
+
+func (e *eventManager) AddSubscriber(subURL string) error {
+	e.mu.Lock()
+	for _, sub := range e.subscribers {
+		if sub.GetURL() == subURL {
+			e.mu.Unlock()
+			return nil
+		}
+	}
+	newSub, err := NewSubscriber(subURL)
+	if err != nil {
+		e.mu.Unlock()
+		return err
+	}
+	e.subscribers = append(e.subscribers, newSub)
+	past := e.latestState.GetEvents()
+	e.mu.Unlock()
+
+	for i := range past {
+		ev := past[i]
+		evCopy := ev
+		if err := newSub.Notify(context.Background(), &evCopy); err != nil {
+			fmt.Printf("failed to notify subscriber %s during replay: %v\n", newSub.GetURL(), err) // TODO: handle errors in the middle of the replay
+		}
+	}
+	return nil
+}
+
+func (e *eventManager) GetSubscribers() []events.Subscriber {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	out := make([]events.Subscriber, len(e.subscribers))
+	copy(out, e.subscribers)
+	return out
+}
+
+func (e *eventManager) RemoveSubscriber(url string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for i, sub := range e.subscribers {
+		if sub.GetURL() == url {
+			e.subscribers = append(e.subscribers[:i], e.subscribers[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("subscriber %s not found", url)
+}
+
+// tailResourceKey identifies a resource within a historyRing snapshot, using
+// the same wire-format ResourceType string StoredEvent already carries (no
+// parsing round-trip needed).
+type tailResourceKey struct {
+	resourceType string
+	resourceId   uuid.UUID
+}
+
+func (e *eventManager) QueryEvents(ctx context.Context, q events.EventQuery) ([]events.StoredEvent, error) {
+	e.mu.RLock()
+	tail := e.historyTail.Snapshot()
+	compactionSeq, compactionAt := e.historyTail.CompactionBoundary()
+
+	var all []events.StoredEvent
+	if q.SinceSeq < compactionSeq {
+		// Some events have aged out of the tail. Synthesize a Create for
+		// every live resource that has no representation left in the tail
+		// at all; resources with at least one real tail event don't need
+		// one (upsert semantics mean the tail alone reconstructs them
+		// correctly, so a synthetic entry would only be a redundant
+		// duplicate).
+		inTail := make(map[tailResourceKey]struct{}, len(tail))
+		for _, ev := range tail {
+			inTail[tailResourceKey{ev.ResourceType, ev.ResourceId}] = struct{}{}
+		}
+		for _, ev := range e.latestState.GetEvents() {
+			key := tailResourceKey{ev.ResourceType.WireKind(), ev.ResourceId}
+			if _, present := inTail[key]; present {
+				continue
+			}
+			all = append(all, events.NewStoredEvent(
+				compactionSeq, compactionAt, ev.ResourceType, events.CreateOperation, ev.ResourceId, ev.Objects,
+			))
+		}
+	}
+	all = append(all, tail...)
+	e.mu.RUnlock()
+
+	limit := q.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+
+	var results []events.StoredEvent
+	for _, ev := range all {
+		if ev.SequenceId <= q.SinceSeq {
+			continue
+		}
+		if q.Operation != nil && ev.Operation != q.Operation.WireOperation() {
+			continue
+		}
+		if q.ResourceType != nil && ev.ResourceType != q.ResourceType.WireKind() {
+			continue
+		}
+		if q.ResourceId != nil && ev.ResourceId != *q.ResourceId {
+			continue
+		}
+		entry := ev
+		if !q.IncludePayload {
+			entry.Objects = nil
+		}
+		results = append(results, entry)
+		if len(results) >= limit {
+			break
+		}
+	}
+	return results, nil
+}
+```
+
+- [ ] **Step 4: Update `internal/events/recording_sink.go`**
+
+Replace the body of `Receive`:
+
+```go
+func (r *recordingSink) Receive(resType events.ResourceType, op events.Operation, resourceId uuid.UUID, objects ...any) error {
+	ev := events.Event{
+		ResourceType: resType,
+		Operation:    op,
+		ResourceId:   resourceId,
+		Objects:      objects,
+	}
+
+	r.mgr.mu.Lock()
+	r.mgr.latestState.Receive(resType, op, resourceId, objects...)
+	r.mgr.sequenceNumber++
+	r.mgr.historyTail.Add(events.NewStoredEvent(
+		r.mgr.sequenceNumber, time.Now(), resType, op, resourceId, objects,
+	))
+	subs := make([]events.Subscriber, len(r.mgr.subscribers))
+	copy(subs, r.mgr.subscribers)
+	r.mgr.mu.Unlock()
+
+	for _, sub := range subs {
+		s := sub
+		evCopy := ev
+		go func() {
+			err := s.Notify(context.Background(), &evCopy)
+			if err != nil {
+				fmt.Printf("failed to notify subscriber %s: %v\n", s.GetURL(), err)
+			}
+		}()
+	}
+	return nil
+}
+```
+
+(Only the two lines inside the lock change: `_ = r.mgr.masterList.Receive(...)` → `r.mgr.latestState.Receive(...)` (no longer discarding a return value — `latestStateStore.Receive` returns nothing), and `r.mgr.storedEvents = append(...)` → `r.mgr.historyTail.Add(...)`. The rest of the file, including its imports, is unchanged.)
+
+- [ ] **Step 5: Update doc comments in `pkg/events/history.go`**
+
+Read the current `EventQuery`/`EventQuerier` doc comments (lines 32-45) and replace with:
+
+```go
+// EventQuery defines filters and pagination for querying event history.
+//
+// SinceSeq queries reaching further back than the EventManager's configured
+// retention window (see eventmgr.WithHistoryLimit) still succeed: history
+// for resources that aged out of the window but still exist is synthesized
+// as a Create carrying their current state, so replaying the full result in
+// order reconstructs the same state a new subscriber would receive.
+type EventQuery struct {
+	Operation      *Operation
+	ResourceType   *ResourceType
+	ResourceId     *uuid.UUID
+	SinceSeq       uint64 // return events with SequenceId > SinceSeq
+	Limit          int    // max results; 0 means default (100)
+	IncludePayload bool
+}
+
+// EventQuerier can query stored event history.
+type EventQuerier interface {
+	QueryEvents(ctx context.Context, q EventQuery) ([]StoredEvent, error)
+}
+```
+
+- [ ] **Step 6: Run the full `internal/events` package test suite**
+
+Run: `go test ./internal/events/... -v`
+Expected: PASS — every existing test (`TestQueryEvents`, `manager_test.go`'s ginkgo specs, `TestLatestStateStore_*`, `TestHistoryRing_*`) plus the new `TestQueryEvents_CompactionSynthesizesEvictedResourceState` subtests.
+
+- [ ] **Step 7: Run `go vet` and `go build` across the module**
+
+Run: `go build ./... && go vet ./...`
+Expected: no errors (confirms no other package references the removed `masterList`/`storedEvents` field names — there shouldn't be any, since they were unexported).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/events/manager.go internal/events/recording_sink.go internal/events/query_events_test.go pkg/events/history.go
+git commit -m "$(cat <<'EOF'
+Wire eventManager to bounded latestStateStore and historyRing
+
+masterList (unbounded, subscriber replay) and storedEvents (unbounded,
+history API) are replaced by latestStateStore and historyRing. Heap for
+subscriber replay now scales with live resource count; heap for history
+queries is bounded by a configurable retention limit (default 1000).
+Queries reaching past the retention window synthesize missing resource
+state from latestStateStore at query time, so no per-eviction bookkeeping
+beyond a compaction boundary marker is needed.
+
+NewEventManager gains a variadic ...Option parameter (WithHistoryLimit);
+all existing zero-arg call sites are unaffected.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Configurable retention limit through `pkg/backend`
+
+**Files:**
+- Modify: `pkg/backend/backend.go`
+- Test: `pkg/backend/backend_test.go` (append)
+
+**Interfaces:**
+- Consumes: `eventmgr.WithHistoryLimit(n int) eventmgr.Option`, `eventmgr.NewEventManager(opts ...eventmgr.Option)` (Task 3).
+- Produces: `type Option func(*config)`, `func WithEventHistoryLimit(n int) Option`, `func New(opts ...Option) (Backend, error)` (signature change: now variadic; existing zero-arg calls keep compiling).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/backend/backend_test.go`, inside the existing `Describe("New", func() { ... })` block (add as a new `It` alongside the others):
+
+```go
+		It("propagates WithEventHistoryLimit down to the event manager's history retention", func() {
+			b, err := backend.New(backend.WithEventHistoryLimit(2))
+			Expect(err).NotTo(HaveOccurred())
+
+			sink, err := b.GetEventManager().GetSink()
+			Expect(err).NotTo(HaveOccurred())
+
+			idA := uuid.New()
+			idB := uuid.New()
+			idC := uuid.New()
+			Expect(sink.Receive(events.SystemResource, events.CreateOperation, idA, "a1")).To(Succeed())
+			Expect(sink.Receive(events.SystemResource, events.CreateOperation, idB, "b1")).To(Succeed())
+			Expect(sink.Receive(events.SystemResource, events.CreateOperation, idC, "c1")).To(Succeed())
+
+			results, err := b.GetEventManager().QueryEvents(context.Background(), events.EventQuery{IncludePayload: true})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(HaveLen(3))
+			Expect(results[0].ResourceId).To(Equal(idA))
+			Expect(results[0].Objects).To(Equal([]any{"a1"}))
+		})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/backend/... -run TestBackend -v`
+Expected: FAIL to compile — `backend.WithEventHistoryLimit` doesn't exist yet.
+
+- [ ] **Step 3: Implement the option in `pkg/backend/backend.go`**
+
+Add near the top of the file, after the imports, and change `New`'s signature:
+
+```go
+// config holds construction-time settings for New.
+type config struct {
+	eventHistoryLimit int
+}
+
+// Option configures a Backend at construction time.
+type Option func(*config)
+
+// WithEventHistoryLimit sets how many recent events the event manager's
+// history-query API can serve exactly; see eventmgr.WithHistoryLimit for
+// what happens to queries reaching further back. n must be positive or it
+// is ignored (the event manager's own default applies).
+func WithEventHistoryLimit(n int) Option {
+	return func(c *config) { c.eventHistoryLimit = n }
+}
+```
+
+Change the start of `New`:
+
+```go
+func New(opts ...Option) (Backend, error) {
+	cfg := config{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	var mgrOpts []eventmgr.Option
+	if cfg.eventHistoryLimit > 0 {
+		mgrOpts = append(mgrOpts, eventmgr.WithHistoryLimit(cfg.eventHistoryLimit))
+	}
+	eventMgr, err := eventmgr.NewEventManager(mgrOpts...)
+	if err != nil {
+		return nil, err
+	}
+	// ... rest of the function body is unchanged from here (GetSink, chain, model, etc.)
+```
+
+(Only the first four lines of the function body change: `eventMgr, err := eventmgr.NewEventManager()` becomes the block above; everything after it is untouched.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./pkg/backend/... -v`
+Expected: PASS — all existing `Describe("Backend", ...)` specs plus the new one.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/backend/backend.go pkg/backend/backend_test.go
+git commit -m "$(cat <<'EOF'
+Add backend.WithEventHistoryLimit to configure event history retention
+
+Threads a configurable retention limit through to eventmgr.WithHistoryLimit.
+backend.New gains a variadic ...Option parameter; all existing zero-arg
+call sites are unaffected.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: `--event-history-limit` CLI flag / `EVENT_HISTORY_LIMIT` env var
+
+**Files:**
+- Modify: `cmd/modelsrv/server.go`
+
+**Interfaces:**
+- Consumes: `backend.WithEventHistoryLimit(n int) backend.Option`, `backend.New(opts ...backend.Option)` (Task 4).
+
+- [ ] **Step 1: Add the `strconv` import and `envIntOrDefault` helper**
+
+Add `"strconv"` to the import block (alphabetically, after `"path/filepath"` and before `"runtime"`).
+
+Add this function next to the existing `envOrDefault`/`envDurationOrDefault` helpers (after `envDurationOrDefault`, around line 205):
+
+```go
+func envIntOrDefault(key string, fallback int) int {
+	if v, ok := os.LookupEnv(key); ok {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+```
+
+- [ ] **Step 2: Add the flag variable and registration**
+
+Add alongside the other flag variables (after `var maxConcurrentProbes int`):
+
+```go
+var eventHistoryLimit int
+```
+
+Add alongside the other `serverCmd.Flags()...` registrations (after the `max-concurrent-probes` line):
+
+```go
+	serverCmd.Flags().IntVar(&eventHistoryLimit, "event-history-limit", envIntOrDefault("EVENT_HISTORY_LIMIT", eventmgr.DefaultHistoryLimit), "Number of recent events the /events history API can serve exactly; older queries return synthesized current-state entries instead of an error")
+```
+
+This needs the `eventmgr` package imported for its `DefaultHistoryLimit` constant — add `eventmgr "go.emeland.io/modelsrv/internal/events"` to the import block (grouped with the other `go.emeland.io/modelsrv/...` imports).
+
+- [ ] **Step 3: Pass it through to `backend.New`**
+
+Change the call site:
+
+```go
+			b, err := backend.New(backend.WithEventHistoryLimit(eventHistoryLimit))
+```
+
+- [ ] **Step 4: Verify it builds and the flag is wired**
+
+Run: `go build ./... && go run . server --help 2>&1 | grep -A1 event-history-limit`
+Expected: the build succeeds and the help output shows the new flag with its default value (1000).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/modelsrv/server.go
+git commit -m "$(cat <<'EOF'
+Add --event-history-limit flag / EVENT_HISTORY_LIMIT env var
+
+Makes the event manager's history retention window configurable at the
+process level, following the existing envOrDefault flag pattern.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: End-to-end verification (no code changes)
+
+**Files:** none modified — this task only runs existing and newly-added test suites plus the load/scale harness to confirm the heap-scaling goal from the spec is actually met.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `go test $(go list ./... | grep -v /e2e) -v 2>&1 | tail -100`
+Expected: all packages pass, including `internal/events`, `pkg/backend`, `pkg/events`, and every `pkg/model/...` package that constructs an `events.ListSink` directly (unaffected, since `pkg/events.ListSink` itself was not changed).
+
+- [ ] **Step 2: Run the load/scale harness before-vs-after comparison**
+
+This was already possible before this change (heap scaling with total events); now confirm it scales with resource count instead:
+
+Run: `make test-load-scale LOAD_SCALE_INSTANCE_COUNTS=10,100,1000 LOAD_SCALE_CHANGE_COUNTS=10,100,1000`
+
+Expected: the generated `test/loadscale/load_scale_report.md` shows `Heap Alloc (after)` growing primarily with the `Instances/Resource` column and staying roughly flat across the `Changes/Instance` column for a fixed instance count — the opposite of pre-change behavior, where heap grew with `Total Events` (instances × changes) regardless of how the two factors were split.
+
+- [ ] **Step 3: Report the before/after comparison**
+
+Read `test/loadscale/load_scale_report.md` and summarize, for a fixed instance count (e.g. 100), how heap alloc changes across change counts (10/100/1000) — it should now be close to flat, confirming the fix. No commit needed for this task (verification only); if the report reveals a regression, stop and fix it in the relevant earlier task before proceeding.

--- a/docs/superpowers/plans/2026-07-27-event-store-compaction.md
+++ b/docs/superpowers/plans/2026-07-27-event-store-compaction.md
@@ -632,7 +632,7 @@ func (e *eventManager) QueryEvents(ctx context.Context, q events.EventQuery) ([]
 	tail := e.historyTail.Snapshot()
 	compactionSeq, compactionAt := e.historyTail.CompactionBoundary()
 
-	var all []events.StoredEvent
+	var synthetic []events.StoredEvent
 	if q.SinceSeq < compactionSeq {
 		// Some events have aged out of the tail. Synthesize a Create for
 		// every live resource that has no representation left in the tail
@@ -649,12 +649,11 @@ func (e *eventManager) QueryEvents(ctx context.Context, q events.EventQuery) ([]
 			if _, present := inTail[key]; present {
 				continue
 			}
-			all = append(all, events.NewStoredEvent(
+			synthetic = append(synthetic, events.NewStoredEvent(
 				compactionSeq, compactionAt, ev.ResourceType, events.CreateOperation, ev.ResourceId, ev.Objects,
 			))
 		}
 	}
-	all = append(all, tail...)
 	e.mu.RUnlock()
 
 	limit := q.Limit
@@ -662,27 +661,40 @@ func (e *eventManager) QueryEvents(ctx context.Context, q events.EventQuery) ([]
 		limit = 100
 	}
 
-	var results []events.StoredEvent
-	for _, ev := range all {
+	matches := func(ev events.StoredEvent) (events.StoredEvent, bool) {
 		if ev.SequenceId <= q.SinceSeq {
-			continue
+			return events.StoredEvent{}, false
 		}
 		if q.Operation != nil && ev.Operation != q.Operation.WireOperation() {
-			continue
+			return events.StoredEvent{}, false
 		}
 		if q.ResourceType != nil && ev.ResourceType != q.ResourceType.WireKind() {
-			continue
+			return events.StoredEvent{}, false
 		}
 		if q.ResourceId != nil && ev.ResourceId != *q.ResourceId {
-			continue
+			return events.StoredEvent{}, false
 		}
 		entry := ev
 		if !q.IncludePayload {
 			entry.Objects = nil
 		}
-		results = append(results, entry)
-		if len(results) >= limit {
-			break
+		return entry, true
+	}
+
+	var results []events.StoredEvent
+	// Synthetic prefix is uncapped by Limit (shared compactionSeq would
+	// break SinceSeq pagination if a page boundary landed inside it).
+	for _, ev := range synthetic {
+		if entry, ok := matches(ev); ok {
+			results = append(results, entry)
+		}
+	}
+	for _, ev := range tail {
+		if entry, ok := matches(ev); ok {
+			results = append(results, entry)
+			if len(results) >= limit {
+				break
+			}
 		}
 	}
 	return results, nil

--- a/docs/superpowers/specs/2026-07-27-event-store-compaction-design.md
+++ b/docs/superpowers/specs/2026-07-27-event-store-compaction-design.md
@@ -1,0 +1,293 @@
+# Event store compaction: bounded memory for subscriber replay and history queries
+
+Date: 2026-07-27
+Status: approved, pending implementation
+
+## Problem
+
+`internal/events.eventManager` (`internal/events/manager.go`) keeps two
+in-memory logs that both grow without bound, one entry per event the model
+ever receives:
+
+- `masterList` (`*events.ListSink`, from `pkg/events/events.go`) — records
+  every event ever seen, used only to replay past state to a newly-added
+  subscriber (`AddSubscriber`).
+- `storedEvents` (`[]events.StoredEvent`) — records every event ever seen,
+  used to serve the `/events` history-query API (`QueryEvents`,
+  `SinceSeq`-based pagination). Already flagged in code with
+  `// TODO: add a cap/eviction strategy for production use`.
+
+`test/loadscale/load_scale_test.go` (added in 956679d) demonstrates the
+resulting heap growth: for a fixed number of resources, heap usage scales
+with the number of *changes* applied, not the number of *resources*, because
+both logs retain full history forever.
+
+## Goals
+
+1. `masterList`: heap usage must scale with the number of **live** (not yet
+   deleted) resources, not the total number of events ever observed. From
+   outside the system, subscriber replay must remain observably equivalent —
+   a new subscriber ends up with the same model state as before.
+2. `storedEvents`: heap usage must be bounded by a **configurable retention
+   limit** (default 1000 events), not the total number of events ever
+   observed. Once the limit is exceeded, evicted history must not simply
+   vanish: querying further back than the retention window must synthesize
+   the missing prefix as a "Create" event carrying each live resource's
+   current state, such that applying the full response (synthetic prefix +
+   retained tail) reconstructs the same overall state that a new subscriber
+   would receive via `masterList`'s replay.
+3. No other externally observable behavior changes (API shapes, semantics of
+   in-window queries, subscriber replay content) except as described in (2).
+
+## Non-goals
+
+- `pkg/events.ListSink` (the public type) is untouched. It is a full-fidelity
+  test double used across ~30 test files to assert exact event sequences
+  (`GetEvents()[0]`, `[1]`, ...) and is unrelated to the two logs above.
+- No change to `EventQuery`/wire API shapes, sequence ID semantics, or
+  `GetCurrentSequenceId`/`IncrementSequenceId`.
+- No attempt to make the synthesized prefix historically exact for resources
+  that receive further updates within the retained tail (see "Correctness
+  argument" below) — only final-state equivalence is guaranteed, matching
+  what the user asked for.
+
+## Architecture
+
+### Shared compacted store: `latestState`
+
+Replaces `masterList`. A single per-resource compacted structure, private to
+`internal/events` (package `eventmgr`), living in a new file
+`internal/events/latest_state.go`:
+
+```go
+type resourceKey struct {
+    resType events.ResourceType
+    id      uuid.UUID
+}
+
+type latestStateStore struct {
+    order []resourceKey
+    state map[resourceKey]events.Event
+}
+```
+
+- `Receive(resType, op, resourceId, objects...)`: on `Create`/`Update`, upsert
+  `state[key]`; if `key` is new, append it to `order`. On `Delete`, remove
+  `key` from both `state` and `order` entirely.
+- `GetEvents() []events.Event`: walks `order`, returns one `Event` per live
+  resource, **always with `Operation` rewritten to `CreateOperation`**
+  regardless of the resource's actual last operation. Rationale: to any
+  observer receiving this snapshot as their first knowledge of the resource
+  (a new subscriber, or a history query starting before the retention
+  window), the resource is first appearing now — presenting it as anything
+  but a Create would be misleading, and the model's replication apply logic
+  (`pkg/model/event_apply.go`) already treats Create and Update identically
+  (both go through `applyReplicationUpsert`), so this is a safe, uniform
+  rule, not a special case.
+- No internal mutex: every call site already holds `eventManager.mu`
+  (`ListSink`'s own mutex was redundant here and is dropped).
+- `order` removal on delete is a linear scan (`O(n)` in live resource count).
+  This is a deliberate simplification — the goal is bounded *heap*, not
+  optimal delete latency, and there is no stated performance requirement
+  beyond memory. If delete-heavy workloads make this a bottleneck later, an
+  intrusive doubly-linked-list (LRU-style) index can replace the slice scan
+  without changing the public shape of this type.
+
+Used by:
+- `AddSubscriber` (unchanged call site shape: `e.latestState.GetEvents()`).
+- `QueryEvents`, as the source of synthesized prefix entries (see below).
+
+### Bounded tail: `historyTail`
+
+Replaces `storedEvents`. A fixed-capacity ring buffer of raw
+`events.StoredEvent`, in a new file `internal/events/history_ring.go`:
+
+```go
+type historyRing struct {
+    buf   []events.StoredEvent // len == limit, preallocated once
+    limit int
+    next  int    // write cursor
+    size  int    // valid entries, <= limit
+
+    compactionSeq uint64    // SequenceId of the most recently evicted entry
+    compactionAt  time.Time // Timestamp of the most recently evicted entry
+}
+```
+
+- `newHistoryRing(limit int) *historyRing`: preallocates `buf` at length
+  `limit` once; the array is never grown, so heap usage for this structure is
+  a fixed function of `limit`, independent of event volume.
+- `Add(ev events.StoredEvent)`: if the buffer is full, the slot about to be
+  overwritten (`buf[next]`) holds the current oldest entry — before
+  overwriting, its `SequenceId`/`Timestamp` become the new
+  `compactionSeq`/`compactionAt`. Then writes `ev` at `next` and advances
+  `next = (next + 1) % limit`.
+- `Snapshot() []events.StoredEvent`: returns a copy of retained entries,
+  oldest to newest (handles the wraparound case).
+- `CompactionBoundary() (uint64, time.Time)`: returns `compactionSeq`,
+  `compactionAt`.
+
+No internal mutex, same rationale as `latestStateStore` — always accessed
+under `eventManager.mu`.
+
+### `QueryEvents`
+
+```go
+func (e *eventManager) QueryEvents(ctx context.Context, q events.EventQuery) ([]events.StoredEvent, error) {
+    e.mu.RLock()
+    tail := e.historyTail.Snapshot()
+    compactionSeq, compactionAt := e.historyTail.CompactionBoundary()
+    var all []events.StoredEvent
+    if q.SinceSeq < compactionSeq {
+        for _, ev := range e.latestState.GetEvents() {
+            all = append(all, events.NewStoredEvent(
+                compactionSeq, compactionAt, ev.ResourceType, events.CreateOperation, ev.ResourceId, ev.Objects,
+            ))
+        }
+    }
+    all = append(all, tail...)
+    e.mu.RUnlock()
+
+    // existing filter/limit loop, unchanged
+    ...
+}
+```
+
+- When nothing has ever been evicted (`compactionSeq == 0`, since real
+  `SequenceId`s start at 1), `q.SinceSeq < compactionSeq` is always false —
+  behavior is byte-for-byte identical to the current unbounded
+  implementation. Divergence is only observable once the retention limit has
+  actually been exceeded.
+- All synthesized entries share `SequenceId = compactionSeq`, so they sort
+  correctly before the real tail (whose oldest entry has
+  `SequenceId = compactionSeq + 1`), and existing `SinceSeq`/`Operation`/
+  `ResourceType`/`ResourceId`/`Limit`/`IncludePayload` filtering applies to
+  them unchanged — no new filter branches needed.
+- Ordering of synthesized entries follows `latestState`'s insertion order
+  (creation order), matching today's general "older resources first"
+  character of the log.
+
+### Correctness argument for goal (2)
+
+Claim: applying the full response (synthetic prefix, in order, followed by
+the retained tail, in order) always reconstructs the same final state as
+`latestState.GetEvents()` (i.e. what a new subscriber gets).
+
+- Resources with no further real events in the tail: the synthetic entry
+  *is* their current state (nothing changed since). Final state after
+  applying it matches `latestState` trivially.
+- Resources with further real events in the tail: those real events are
+  replayed, in their correct relative order, *after* the synthetic entry
+  (all tail `SequenceId`s exceed `compactionSeq`). Because
+  `applyReplicationUpsert` is last-write-wins per resource, the last real
+  tail event for that resource determines the final state, which by
+  construction equals what's currently in `latestState` — regardless of
+  what the synthetic entry said. The synthetic entry only affects
+  intermediate (not final) state for these resources.
+- Deleted resources: absent from `latestState`, so no synthetic entry is
+  produced. If a real Delete event for that resource is still in the tail,
+  it's a harmless no-op delete-of-nothing. If the Delete event itself has
+  already been evicted, the resource is correctly absent from the whole
+  response.
+
+This holds without needing per-eviction bookkeeping beyond
+`compactionSeq`/`compactionAt` — the synthesis is computed lazily at query
+time directly from the always-current `latestState`.
+
+## Configuration
+
+The retention limit becomes configurable via the functional-options pattern,
+keeping all existing zero-arg call sites (`backend.New()`,
+`eventmgr.NewEventManager()`, ~15 call sites across tests and
+`cmd/modelsrv/server.go`) source-compatible and behaviorally unchanged
+(default 1000):
+
+```go
+// internal/events
+const DefaultHistoryLimit = 1000
+
+type Option func(*eventManager)
+
+func WithHistoryLimit(n int) Option {
+    return func(e *eventManager) {
+        if n > 0 {
+            e.historyLimit = n
+        }
+    }
+}
+
+func NewEventManager(opts ...Option) (events.EventManager, error)
+```
+
+```go
+// pkg/backend
+type Option func(*config)
+
+func WithEventHistoryLimit(n int) Option {
+    return func(c *config) { c.eventHistoryLimit = n }
+}
+
+func New(opts ...Option) (Backend, error)
+```
+
+`cmd/modelsrv/server.go` gains a new flag, following the existing
+`envOrDefault` pattern used for the other flags in that file:
+
+```go
+var eventHistoryLimit int
+...
+serverCmd.Flags().IntVar(&eventHistoryLimit, "event-history-limit",
+    envIntOrDefault("EVENT_HISTORY_LIMIT", eventmgr.DefaultHistoryLimit),
+    "Number of recent events to retain for exact history queries; older queries return synthesized current-state entries")
+```
+
+wired through as `backend.New(backend.WithEventHistoryLimit(eventHistoryLimit))`.
+A new `envIntOrDefault` helper is added alongside the existing
+`envOrDefault`/`envDurationOrDefault` helpers.
+
+## Files touched
+
+- `internal/events/manager.go` — field renames (`masterList` → `latestState`,
+  `storedEvents` → `historyTail`), `NewEventManager` options,
+  `AddSubscriber`, `QueryEvents`.
+- `internal/events/recording_sink.go` — update field references and the
+  `storedEvents` append to `historyTail.Add(...)`.
+- `internal/events/latest_state.go` — new.
+- `internal/events/history_ring.go` — new.
+- `pkg/backend/backend.go` — `Option`/`WithEventHistoryLimit`, `New(opts
+  ...Option)`.
+- `cmd/modelsrv/server.go` — new flag/env var, `envIntOrDefault` helper.
+
+Not touched: `pkg/events/events.go` (`ListSink` stays as-is),
+`pkg/events/history.go` (`EventQuery`/`StoredEvent` shapes unchanged, only
+doc comments updated to describe compaction).
+
+## Testing plan
+
+- `internal/events/latest_state_test.go` (new): upsert/overwrite semantics,
+  delete removes from both map and order, re-create after delete re-appends
+  at the end of order, `GetEvents()` always reports `CreateOperation`.
+- `internal/events/history_ring_test.go` (new): fills under capacity
+  (`compactionSeq` stays 0), wraparound overwrite, `Snapshot()` ordering
+  correctness, `CompactionBoundary()` tracks the right evicted entry.
+- `internal/events/query_events_test.go` (existing, 4 events well under the
+  default 1000 cap): unaffected, add a new sub-test that constructs a
+  manager with `WithHistoryLimit(2)` (or similar small number), pushes past
+  the cap, and asserts: (a) a query with `SinceSeq` before the eviction
+  boundary returns a synthesized `Create` reflecting current state for the
+  evicted resource, (b) a query with `SinceSeq` inside the retained tail is
+  unaffected, (c) applying the full synthesized+tail response for a resource
+  that receives further tail updates ends up matching
+  `mgr.GetSubscribers()`-style replay content (i.e. `latestState`).
+- `internal/events/manager_test.go` (existing): verify `AddSubscriber`
+  replay is unaffected for the common case (events well under the cap) and
+  correctly reflects compacted state once resources have been deleted.
+- `make test-load-scale`: run before/after to confirm heap now scales with
+  resource count (via `LOAD_SCALE_INSTANCE_COUNTS`) rather than change count
+  (via `LOAD_SCALE_CHANGE_COUNTS`), using the existing harness added in
+  956679d.
+
+## Open questions / risks
+
+None outstanding — scope and correctness invariants were confirmed with the
+user during design review.

--- a/docs/superpowers/specs/2026-07-27-event-store-compaction-design.md
+++ b/docs/superpowers/specs/2026-07-27-event-store-compaction-design.md
@@ -32,10 +32,12 @@ both logs retain full history forever.
    limit** (default 1000 events), not the total number of events ever
    observed. Once the limit is exceeded, evicted history must not simply
    vanish: querying further back than the retention window must synthesize
-   the missing prefix as a "Create" event carrying each live resource's
-   current state, such that applying the full response (synthetic prefix +
-   retained tail) reconstructs the same overall state that a new subscriber
-   would receive via `masterList`'s replay.
+   the missing prefix as a "Create" event carrying the current state of
+   each live resource that has no remaining representation in the retained
+   tail (resources already present in the tail are skipped — a synthetic
+   Create would only duplicate them). Applying the full response
+   (synthetic prefix + retained tail) still reconstructs the same overall
+   state that a new subscriber would receive via `masterList`'s replay.
 3. No other externally observable behavior changes (API shapes, semantics of
    in-window queries, subscriber replay content) except as described in (2).
 
@@ -46,10 +48,10 @@ both logs retain full history forever.
   (`GetEvents()[0]`, `[1]`, ...) and is unrelated to the two logs above.
 - No change to `EventQuery`/wire API shapes, sequence ID semantics, or
   `GetCurrentSequenceId`/`IncrementSequenceId`.
-- No attempt to make the synthesized prefix historically exact for resources
-  that receive further updates within the retained tail (see "Correctness
-  argument" below) — only final-state equivalence is guaranteed, matching
-  what the user asked for.
+- No attempt to synthesize entries for resources still represented in the
+  retained tail, nor to make any synthetic prefix historically exact (see
+  "Correctness argument" below) — only final-state equivalence is
+  guaranteed.
 
 ## Architecture
 
@@ -137,18 +139,25 @@ func (e *eventManager) QueryEvents(ctx context.Context, q events.EventQuery) ([]
     e.mu.RLock()
     tail := e.historyTail.Snapshot()
     compactionSeq, compactionAt := e.historyTail.CompactionBoundary()
-    var all []events.StoredEvent
+    var synthetic []events.StoredEvent
     if q.SinceSeq < compactionSeq {
+        // Skip resources already present in the tail — synthesizing them
+        // would only produce redundant Creates that the tail already covers.
+        inTail := /* set of (ResourceType, ResourceId) in tail */
         for _, ev := range e.latestState.GetEvents() {
-            all = append(all, events.NewStoredEvent(
+            if _, present := inTail[key]; present {
+                continue
+            }
+            synthetic = append(synthetic, events.NewStoredEvent(
                 compactionSeq, compactionAt, ev.ResourceType, events.CreateOperation, ev.ResourceId, ev.Objects,
             ))
         }
     }
-    all = append(all, tail...)
     e.mu.RUnlock()
 
-    // existing filter/limit loop, unchanged
+    // Filters (SinceSeq/Operation/ResourceType/ResourceId/IncludePayload)
+    // apply to both synthetic and tail. Limit caps the retained tail only:
+    // the synthetic prefix is always delivered in full (see below).
     ...
 }
 ```
@@ -158,11 +167,21 @@ func (e *eventManager) QueryEvents(ctx context.Context, q events.EventQuery) ([]
   behavior is byte-for-byte identical to the current unbounded
   implementation. Divergence is only observable once the retention limit has
   actually been exceeded.
+- Synthesis is partial: only live resources with **no** remaining entry in
+  the retained tail get a synthetic Create. Resources already represented
+  in the tail are omitted from the prefix (response shape is shorter than
+  "one synthetic entry per live resource"; final-state LWW still holds
+  because the tail alone reconstructs those resources).
 - All synthesized entries share `SequenceId = compactionSeq`, so they sort
   correctly before the real tail (whose oldest entry has
-  `SequenceId = compactionSeq + 1`), and existing `SinceSeq`/`Operation`/
-  `ResourceType`/`ResourceId`/`Limit`/`IncludePayload` filtering applies to
-  them unchanged — no new filter branches needed.
+  `SequenceId = compactionSeq + 1`). Existing `SinceSeq`/`Operation`/
+  `ResourceType`/`ResourceId`/`IncludePayload` filters apply to them;
+  **`Limit` does not** — the synthetic prefix is always returned in full
+  within a single response. Capping it would let a paginating client
+  (`SinceSeq` = last delivered `SequenceId`, which equals `compactionSeq`
+  for every synthetic entry) permanently skip whatever didn't fit on the
+  first page. Once `SinceSeq` reaches the retention boundary, subsequent
+  calls page the retained tail normally and honor `Limit`.
 - Ordering of synthesized entries follows `latestState`'s insertion order
   (creation order), matching today's general "older resources first"
   character of the log.
@@ -173,17 +192,17 @@ Claim: applying the full response (synthetic prefix, in order, followed by
 the retained tail, in order) always reconstructs the same final state as
 `latestState.GetEvents()` (i.e. what a new subscriber gets).
 
-- Resources with no further real events in the tail: the synthetic entry
-  *is* their current state (nothing changed since). Final state after
-  applying it matches `latestState` trivially.
-- Resources with further real events in the tail: those real events are
-  replayed, in their correct relative order, *after* the synthetic entry
-  (all tail `SequenceId`s exceed `compactionSeq`). Because
-  `applyReplicationUpsert` is last-write-wins per resource, the last real
-  tail event for that resource determines the final state, which by
-  construction equals what's currently in `latestState` — regardless of
-  what the synthetic entry said. The synthetic entry only affects
-  intermediate (not final) state for these resources.
+- Resources with no representation in the tail: the synthetic entry *is*
+  their current state. Final state after applying it matches `latestState`
+  trivially.
+- Resources already present in the tail: no synthetic entry is emitted
+  (would be redundant). The tail's real events alone reconstruct them;
+  because `applyReplicationUpsert` is last-write-wins per resource, the
+  last real tail event determines the final state, which equals
+  `latestState`. (The older "prefix+tail for every live resource" algorithm
+  also reached the same final state via LWW, but produced a longer
+  response and a different intermediate apply path; this design prefers
+  the reduced shape.)
 - Deleted resources: absent from `latestState`, so no synthetic entry is
   produced. If a real Delete event for that resource is still in the tail,
   it's a harmless no-op delete-of-nothing. If the Delete event itself has
@@ -274,11 +293,12 @@ doc comments updated to describe compaction).
   default 1000 cap): unaffected, add a new sub-test that constructs a
   manager with `WithHistoryLimit(2)` (or similar small number), pushes past
   the cap, and asserts: (a) a query with `SinceSeq` before the eviction
-  boundary returns a synthesized `Create` reflecting current state for the
-  evicted resource, (b) a query with `SinceSeq` inside the retained tail is
-  unaffected, (c) applying the full synthesized+tail response for a resource
-  that receives further tail updates ends up matching
-  `mgr.GetSubscribers()`-style replay content (i.e. `latestState`).
+  boundary returns a synthesized `Create` for the evicted resource only
+  (resources still in the tail are not duplicated), (b) a query with
+  `SinceSeq` inside the retained tail is unaffected, (c) the synthetic
+  prefix is returned in full even when `Limit` is smaller than the
+  prefix, (d) applying the full synthesized+tail response ends up matching
+  `latestState`.
 - `internal/events/manager_test.go` (existing): verify `AddSubscriber`
   replay is unaffected for the common case (events well under the cap) and
   correctly reflects compacted state once resources have been deleted.

--- a/internal/events/history_ring.go
+++ b/internal/events/history_ring.go
@@ -1,0 +1,72 @@
+package eventmgr
+
+import (
+	"time"
+
+	"go.emeland.io/modelsrv/pkg/events"
+)
+
+// DefaultHistoryLimit is the number of recent events QueryEvents can serve
+// exactly when no WithHistoryLimit option is given (see manager.go).
+// History reaching further back than this is synthesized from latestState
+// instead of stored verbatim.
+const DefaultHistoryLimit = 1000
+
+// historyRing is a fixed-capacity ring buffer of the most recent
+// StoredEvents. Its backing array is preallocated once at construction, so
+// heap usage is a fixed function of limit, independent of event volume.
+// Every call site holds eventManager.mu, so this type has no locking of its
+// own.
+type historyRing struct {
+	buf   []events.StoredEvent
+	limit int
+	next  int
+	size  int
+
+	compactionSeq uint64
+	compactionAt  time.Time
+}
+
+func newHistoryRing(limit int) *historyRing {
+	if limit <= 0 {
+		limit = DefaultHistoryLimit
+	}
+	return &historyRing{
+		buf:   make([]events.StoredEvent, limit),
+		limit: limit,
+	}
+}
+
+// Add appends ev, overwriting the oldest retained entry once the buffer is
+// full. The overwritten entry's SequenceId/Timestamp become the new
+// compaction boundary, so callers can tell how far back real events are
+// still available.
+func (r *historyRing) Add(ev events.StoredEvent) {
+	if r.size == r.limit {
+		evicted := r.buf[r.next]
+		r.compactionSeq = evicted.SequenceId
+		r.compactionAt = evicted.Timestamp
+	} else {
+		r.size++
+	}
+	r.buf[r.next] = ev
+	r.next = (r.next + 1) % r.limit
+}
+
+// Snapshot returns a copy of the retained entries, oldest to newest.
+func (r *historyRing) Snapshot() []events.StoredEvent {
+	out := make([]events.StoredEvent, r.size)
+	if r.size < r.limit {
+		copy(out, r.buf[:r.size])
+		return out
+	}
+	n := copy(out, r.buf[r.next:])
+	copy(out[n:], r.buf[:r.next])
+	return out
+}
+
+// CompactionBoundary returns the SequenceId/Timestamp of the most recently
+// evicted entry (zero value if nothing has been evicted yet).
+func (r *historyRing) CompactionBoundary() (uint64, time.Time) {
+	return r.compactionSeq, r.compactionAt
+}

--- a/internal/events/history_ring_test.go
+++ b/internal/events/history_ring_test.go
@@ -1,0 +1,59 @@
+package eventmgr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.emeland.io/modelsrv/pkg/events"
+)
+
+func storedEvent(seq uint64) events.StoredEvent {
+	return events.StoredEvent{
+		SequenceId:   seq,
+		Timestamp:    time.Unix(int64(seq), 0),
+		ResourceType: "System",
+		Operation:    "Create",
+	}
+}
+
+func TestHistoryRing_UnderCapacityKeepsCompactionSeqZero(t *testing.T) {
+	r := newHistoryRing(3)
+	r.Add(storedEvent(1))
+	r.Add(storedEvent(2))
+
+	seq, _ := r.CompactionBoundary()
+	assert.Equal(t, uint64(0), seq)
+	assert.Equal(t, []events.StoredEvent{storedEvent(1), storedEvent(2)}, r.Snapshot())
+}
+
+func TestHistoryRing_WraparoundEvictsOldestAndTracksBoundary(t *testing.T) {
+	r := newHistoryRing(2)
+	r.Add(storedEvent(1))
+	r.Add(storedEvent(2))
+	r.Add(storedEvent(3)) // evicts seq 1
+
+	seq, at := r.CompactionBoundary()
+	assert.Equal(t, uint64(1), seq)
+	assert.Equal(t, storedEvent(1).Timestamp, at)
+	assert.Equal(t, []events.StoredEvent{storedEvent(2), storedEvent(3)}, r.Snapshot())
+}
+
+func TestHistoryRing_ContinuedWraparoundKeepsOrder(t *testing.T) {
+	r := newHistoryRing(2)
+	r.Add(storedEvent(1))
+	r.Add(storedEvent(2))
+	r.Add(storedEvent(3))
+	r.Add(storedEvent(4))
+
+	seq, _ := r.CompactionBoundary()
+	assert.Equal(t, uint64(2), seq)
+	assert.Equal(t, []events.StoredEvent{storedEvent(3), storedEvent(4)}, r.Snapshot())
+}
+
+func TestHistoryRing_DefaultsInvalidLimit(t *testing.T) {
+	r := newHistoryRing(0)
+	require.NotPanics(t, func() { r.Add(storedEvent(1)) })
+	assert.Len(t, r.Snapshot(), 1)
+}

--- a/internal/events/latest_state.go
+++ b/internal/events/latest_state.go
@@ -1,0 +1,69 @@
+package eventmgr
+
+import (
+	"github.com/google/uuid"
+	"go.emeland.io/modelsrv/pkg/events"
+)
+
+type resourceKey struct {
+	resType events.ResourceType
+	id      uuid.UUID
+}
+
+// latestStateStore keeps only the most recent event of each live resource,
+// so heap usage scales with the number of resources not yet deleted rather
+// than the total number of events ever observed. Every call site holds
+// eventManager.mu, so this type has no locking of its own.
+type latestStateStore struct {
+	order []resourceKey
+	state map[resourceKey]events.Event
+}
+
+func newLatestStateStore() *latestStateStore {
+	return &latestStateStore{state: make(map[resourceKey]events.Event)}
+}
+
+func (s *latestStateStore) Receive(resType events.ResourceType, op events.Operation, resourceId uuid.UUID, objects ...any) {
+	key := resourceKey{resType: resType, id: resourceId}
+
+	if op == events.DeleteOperation {
+		if _, ok := s.state[key]; ok {
+			delete(s.state, key)
+			s.removeFromOrder(key)
+		}
+		return
+	}
+
+	if _, exists := s.state[key]; !exists {
+		s.order = append(s.order, key)
+	}
+	s.state[key] = events.Event{
+		ResourceType: resType,
+		Operation:    op,
+		ResourceId:   resourceId,
+		Objects:      objects,
+	}
+}
+
+func (s *latestStateStore) removeFromOrder(key resourceKey) {
+	for i, k := range s.order {
+		if k == key {
+			s.order = append(s.order[:i], s.order[i+1:]...)
+			return
+		}
+	}
+}
+
+// GetEvents returns one event per live resource, oldest-creation-first,
+// always reported as a Create: to a party seeing this snapshot as their
+// first knowledge of the resource (a new subscriber, or a history query
+// reaching past the retention window), it is first appearing now.
+func (s *latestStateStore) GetEvents() []events.Event {
+	out := make([]events.Event, 0, len(s.order))
+	for _, key := range s.order {
+		ev := s.state[key]
+		ev.Operation = events.CreateOperation
+		out = append(out, ev)
+	}
+	return out
+}

--- a/internal/events/latest_state_test.go
+++ b/internal/events/latest_state_test.go
@@ -1,0 +1,64 @@
+package eventmgr
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.emeland.io/modelsrv/pkg/events"
+)
+
+func TestLatestStateStore_UpsertReplacesPriorState(t *testing.T) {
+	s := newLatestStateStore()
+	id := uuid.New()
+	s.Receive(events.SystemResource, events.CreateOperation, id, "v1")
+	s.Receive(events.SystemResource, events.UpdateOperation, id, "v2")
+
+	got := s.GetEvents()
+	require.Len(t, got, 1)
+	assert.Equal(t, events.CreateOperation, got[0].Operation)
+	assert.Equal(t, id, got[0].ResourceId)
+	assert.Equal(t, []any{"v2"}, got[0].Objects)
+}
+
+func TestLatestStateStore_DeleteRemovesEntry(t *testing.T) {
+	s := newLatestStateStore()
+	id := uuid.New()
+	s.Receive(events.SystemResource, events.CreateOperation, id, "v1")
+	s.Receive(events.SystemResource, events.DeleteOperation, id)
+
+	assert.Empty(t, s.GetEvents())
+}
+
+func TestLatestStateStore_DeleteUnknownIsNoop(t *testing.T) {
+	s := newLatestStateStore()
+	s.Receive(events.SystemResource, events.DeleteOperation, uuid.New())
+
+	assert.Empty(t, s.GetEvents())
+}
+
+func TestLatestStateStore_OrderPreservedAndRecreateAppendsAtEnd(t *testing.T) {
+	s := newLatestStateStore()
+	idA := uuid.New()
+	idB := uuid.New()
+	s.Receive(events.SystemResource, events.CreateOperation, idA, "a1")
+	s.Receive(events.SystemResource, events.CreateOperation, idB, "b1")
+	s.Receive(events.SystemResource, events.DeleteOperation, idA)
+	s.Receive(events.SystemResource, events.CreateOperation, idA, "a2")
+
+	got := s.GetEvents()
+	require.Len(t, got, 2)
+	assert.Equal(t, idB, got[0].ResourceId)
+	assert.Equal(t, idA, got[1].ResourceId)
+	assert.Equal(t, []any{"a2"}, got[1].Objects)
+}
+
+func TestLatestStateStore_KeyIncludesResourceType(t *testing.T) {
+	s := newLatestStateStore()
+	id := uuid.New()
+	s.Receive(events.SystemResource, events.CreateOperation, id, "sys")
+	s.Receive(events.NodeResource, events.CreateOperation, id, "node")
+
+	assert.Len(t, s.GetEvents(), 2)
+}

--- a/internal/events/manager.go
+++ b/internal/events/manager.go
@@ -5,10 +5,24 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/google/uuid"
 	"go.emeland.io/modelsrv/pkg/events"
 )
 
 var _ events.EventManager = (*eventManager)(nil)
+
+// Option configures an eventManager at construction time.
+type Option func(*eventManager)
+
+// WithHistoryLimit sets how many recent events QueryEvents can serve
+// exactly. n must be positive or it is ignored (the default applies).
+func WithHistoryLimit(n int) Option {
+	return func(e *eventManager) {
+		if n > 0 {
+			e.historyLimit = n
+		}
+	}
+}
 
 type eventManager struct {
 	mu             sync.RWMutex
@@ -16,17 +30,23 @@ type eventManager struct {
 	subscribers    []events.Subscriber
 	sinkFactory    func() (events.EventSink, error)
 
-	masterList   *events.ListSink
-	storedEvents []events.StoredEvent
+	latestState  *latestStateStore
+	historyTail  *historyRing
+	historyLimit int
 	modelSink    events.EventSink
 }
 
-func NewEventManager() (events.EventManager, error) {
+func NewEventManager(opts ...Option) (events.EventManager, error) {
 	e := &eventManager{
 		sequenceNumber: 0,
 		subscribers:    make([]events.Subscriber, 0),
-		masterList:     events.NewListSink(),
+		latestState:    newLatestStateStore(),
+		historyLimit:   DefaultHistoryLimit,
 	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	e.historyTail = newHistoryRing(e.historyLimit)
 	e.sinkFactory = func() (events.EventSink, error) {
 		return e.getOrCreateModelSink(), nil
 	}
@@ -79,7 +99,7 @@ func (e *eventManager) AddSubscriber(subURL string) error {
 		return err
 	}
 	e.subscribers = append(e.subscribers, newSub)
-	past := e.masterList.GetEvents()
+	past := e.latestState.GetEvents()
 	e.mu.Unlock()
 
 	for i := range past {
@@ -112,11 +132,42 @@ func (e *eventManager) RemoveSubscriber(url string) error {
 	return fmt.Errorf("subscriber %s not found", url)
 }
 
+// tailResourceKey identifies a resource within a historyRing snapshot, using
+// the same wire-format ResourceType string StoredEvent already carries (no
+// parsing round-trip needed).
+type tailResourceKey struct {
+	resourceType string
+	resourceId   uuid.UUID
+}
+
 func (e *eventManager) QueryEvents(ctx context.Context, q events.EventQuery) ([]events.StoredEvent, error) {
-	// NOTE: storedEvents only grows via append under write lock. Capturing the slice header
-	// under RLock freezes the length we iterate over; concurrent appends are safe.
 	e.mu.RLock()
-	all := e.storedEvents // TODO: add a cap/eviction strategy for production use
+	tail := e.historyTail.Snapshot()
+	compactionSeq, compactionAt := e.historyTail.CompactionBoundary()
+
+	var all []events.StoredEvent
+	if q.SinceSeq < compactionSeq {
+		// Some events have aged out of the tail. Synthesize a Create for
+		// every live resource that has no representation left in the tail
+		// at all; resources with at least one real tail event don't need
+		// one (upsert semantics mean the tail alone reconstructs them
+		// correctly, so a synthetic entry would only be a redundant
+		// duplicate).
+		inTail := make(map[tailResourceKey]struct{}, len(tail))
+		for _, ev := range tail {
+			inTail[tailResourceKey{ev.ResourceType, ev.ResourceId}] = struct{}{}
+		}
+		for _, ev := range e.latestState.GetEvents() {
+			key := tailResourceKey{ev.ResourceType.WireKind(), ev.ResourceId}
+			if _, present := inTail[key]; present {
+				continue
+			}
+			all = append(all, events.NewStoredEvent(
+				compactionSeq, compactionAt, ev.ResourceType, events.CreateOperation, ev.ResourceId, ev.Objects,
+			))
+		}
+	}
+	all = append(all, tail...)
 	e.mu.RUnlock()
 
 	limit := q.Limit

--- a/internal/events/manager.go
+++ b/internal/events/manager.go
@@ -145,7 +145,7 @@ func (e *eventManager) QueryEvents(ctx context.Context, q events.EventQuery) ([]
 	tail := e.historyTail.Snapshot()
 	compactionSeq, compactionAt := e.historyTail.CompactionBoundary()
 
-	var all []events.StoredEvent
+	var synthetic []events.StoredEvent
 	if q.SinceSeq < compactionSeq {
 		// Some events have aged out of the tail. Synthesize a Create for
 		// every live resource that has no representation left in the tail
@@ -162,12 +162,11 @@ func (e *eventManager) QueryEvents(ctx context.Context, q events.EventQuery) ([]
 			if _, present := inTail[key]; present {
 				continue
 			}
-			all = append(all, events.NewStoredEvent(
+			synthetic = append(synthetic, events.NewStoredEvent(
 				compactionSeq, compactionAt, ev.ResourceType, events.CreateOperation, ev.ResourceId, ev.Objects,
 			))
 		}
 	}
-	all = append(all, tail...)
 	e.mu.RUnlock()
 
 	limit := q.Limit
@@ -175,27 +174,44 @@ func (e *eventManager) QueryEvents(ctx context.Context, q events.EventQuery) ([]
 		limit = 100
 	}
 
-	var results []events.StoredEvent
-	for _, ev := range all {
+	matches := func(ev events.StoredEvent) (events.StoredEvent, bool) {
 		if ev.SequenceId <= q.SinceSeq {
-			continue
+			return events.StoredEvent{}, false
 		}
 		if q.Operation != nil && ev.Operation != q.Operation.WireOperation() {
-			continue
+			return events.StoredEvent{}, false
 		}
 		if q.ResourceType != nil && ev.ResourceType != q.ResourceType.WireKind() {
-			continue
+			return events.StoredEvent{}, false
 		}
 		if q.ResourceId != nil && ev.ResourceId != *q.ResourceId {
-			continue
+			return events.StoredEvent{}, false
 		}
 		entry := ev
 		if !q.IncludePayload {
 			entry.Objects = nil
 		}
-		results = append(results, entry)
-		if len(results) >= limit {
-			break
+		return entry, true
+	}
+
+	var results []events.StoredEvent
+	// The synthesized prefix is delivered in full, uncapped by limit: it
+	// represents live resources with no remaining representation in the
+	// tail at all, and letting a page boundary land inside it would let a
+	// paginating client (SinceSeq = last delivered SequenceId, which for
+	// every synthetic entry equals compactionSeq) skip the rest forever,
+	// since the next call's SinceSeq would no longer be < compactionSeq.
+	for _, ev := range synthetic {
+		if entry, ok := matches(ev); ok {
+			results = append(results, entry)
+		}
+	}
+	for _, ev := range tail {
+		if entry, ok := matches(ev); ok {
+			results = append(results, entry)
+			if len(results) >= limit {
+				break
+			}
 		}
 	}
 	return results, nil

--- a/internal/events/manager_test.go
+++ b/internal/events/manager_test.go
@@ -35,6 +35,10 @@ func emitSystemCreate(sink events.EventSink, id uuid.UUID) error {
 	return sink.Receive(events.SystemResource, events.CreateOperation, id, sys)
 }
 
+func emitSystemDelete(sink events.EventSink, id uuid.UUID) error {
+	return sink.Receive(events.SystemResource, events.DeleteOperation, id)
+}
+
 var _ = Describe("EventManager", func() {
 	var (
 		ctx context.Context
@@ -92,6 +96,22 @@ var _ = Describe("EventManager", func() {
 
 			Expect(em.AddSubscriber(srv.URL + "/api")).To(Succeed())
 			Expect(atomic.LoadInt32(count)).To(Equal(int32(2)))
+		})
+
+		It("replays only currently-live resources, reflecting deletes that happened before the subscriber was added", func() {
+			sink, err := em.GetSink()
+			Expect(err).NotTo(HaveOccurred())
+			id1 := uuid.New()
+			id2 := uuid.New()
+			Expect(emitSystemCreate(sink, id1)).To(Succeed())
+			Expect(emitSystemCreate(sink, id2)).To(Succeed())
+			Expect(emitSystemDelete(sink, id1)).To(Succeed())
+
+			srv, count := newPushCountingServer()
+			defer srv.Close()
+
+			Expect(em.AddSubscriber(srv.URL + "/api")).To(Succeed())
+			Expect(atomic.LoadInt32(count)).To(Equal(int32(1)))
 		})
 
 		It("delivers no replay when there were no prior events", func() {

--- a/internal/events/query_events_test.go
+++ b/internal/events/query_events_test.go
@@ -82,3 +82,75 @@ func TestQueryEvents(t *testing.T) {
 		assert.NotNil(t, results[0].Objects)
 	})
 }
+
+func TestQueryEvents_CompactionSynthesizesEvictedResourceState(t *testing.T) {
+	mgr, err := NewEventManager(WithHistoryLimit(2))
+	require.NoError(t, err)
+
+	sink, err := mgr.GetSink()
+	require.NoError(t, err)
+
+	idA := uuid.New()
+	idB := uuid.New()
+	idC := uuid.New()
+
+	require.NoError(t, sink.Receive(events.SystemResource, events.CreateOperation, idA, "a1")) // seq 1
+	require.NoError(t, sink.Receive(events.SystemResource, events.CreateOperation, idB, "b1")) // seq 2
+	require.NoError(t, sink.Receive(events.SystemResource, events.CreateOperation, idC, "c1")) // seq 3, evicts seq 1 (idA)
+
+	ctx := context.Background()
+
+	t.Run("query reaching past the retention window synthesizes a Create for the evicted resource", func(t *testing.T) {
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{IncludePayload: true})
+		require.NoError(t, err)
+		require.Len(t, results, 3)
+
+		assert.Equal(t, idA, results[0].ResourceId)
+		assert.Equal(t, "Create", results[0].Operation)
+		assert.Equal(t, []any{"a1"}, results[0].Objects)
+
+		assert.Equal(t, idB, results[1].ResourceId)
+		assert.Equal(t, uint64(2), results[1].SequenceId)
+
+		assert.Equal(t, idC, results[2].ResourceId)
+		assert.Equal(t, uint64(3), results[2].SequenceId)
+	})
+
+	t.Run("query inside the retained tail is unaffected by compaction", func(t *testing.T) {
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{SinceSeq: 2})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, idC, results[0].ResourceId)
+	})
+
+	t.Run("a resource still present in the tail is not duplicated by synthesis", func(t *testing.T) {
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{ResourceId: &idC})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, uint64(3), results[0].SequenceId)
+	})
+
+	t.Run("an evicted resource updated again reflects the newer value as its last entry", func(t *testing.T) {
+		require.NoError(t, sink.Receive(events.SystemResource, events.UpdateOperation, idA, "a2")) // seq 4, evicts seq 2 (idB)
+
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{ResourceId: &idA, IncludePayload: true})
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+		assert.Equal(t, []any{"a2"}, results[len(results)-1].Objects)
+	})
+
+	t.Run("under the cap, behavior is unaffected by compaction entirely", func(t *testing.T) {
+		mgr2, err := NewEventManager(WithHistoryLimit(1000))
+		require.NoError(t, err)
+		sink2, err := mgr2.GetSink()
+		require.NoError(t, err)
+		id := uuid.New()
+		require.NoError(t, sink2.Receive(events.SystemResource, events.CreateOperation, id, "only"))
+
+		results, err := mgr2.QueryEvents(ctx, events.EventQuery{IncludePayload: true})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, uint64(1), results[0].SequenceId)
+		assert.Equal(t, []any{"only"}, results[0].Objects)
+	})
+}

--- a/internal/events/query_events_test.go
+++ b/internal/events/query_events_test.go
@@ -2,6 +2,7 @@ package eventmgr
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -153,4 +154,43 @@ func TestQueryEvents_CompactionSynthesizesEvictedResourceState(t *testing.T) {
 		assert.Equal(t, uint64(1), results[0].SequenceId)
 		assert.Equal(t, []any{"only"}, results[0].Objects)
 	})
+}
+
+func TestQueryEvents_PaginationDeliversFullSyntheticPrefixDespiteLimit(t *testing.T) {
+	mgr, err := NewEventManager(WithHistoryLimit(2))
+	require.NoError(t, err)
+
+	sink, err := mgr.GetSink()
+	require.NoError(t, err)
+
+	const liveCount = 10
+	ids := make([]uuid.UUID, liveCount)
+	for i := range ids {
+		ids[i] = uuid.New()
+		require.NoError(t, sink.Receive(events.SystemResource, events.CreateOperation, ids[i], fmt.Sprintf("v%d", i)))
+	}
+	// Ring capacity is 2, so by now only the last 2 creates remain in the
+	// tail; the other 8 resources are live-but-evicted and must come back
+	// via synthesis, in full, even though each page's Limit (3) is smaller
+	// than that.
+
+	ctx := context.Background()
+	seen := make(map[uuid.UUID]bool)
+	sinceSeq := uint64(0)
+	for page := 0; page < 20 && len(seen) < liveCount; page++ {
+		results, err := mgr.QueryEvents(ctx, events.EventQuery{SinceSeq: sinceSeq, Limit: 3})
+		require.NoError(t, err)
+		if len(results) == 0 {
+			break
+		}
+		for _, r := range results {
+			seen[r.ResourceId] = true
+		}
+		sinceSeq = results[len(results)-1].SequenceId
+	}
+
+	assert.Len(t, seen, liveCount, "every live resource must be delivered exactly once across pagination, with no silent loss")
+	for _, id := range ids {
+		assert.True(t, seen[id], "resource %s was never delivered", id)
+	}
 }

--- a/internal/events/recording_sink.go
+++ b/internal/events/recording_sink.go
@@ -9,7 +9,8 @@ import (
 	"go.emeland.io/modelsrv/pkg/events"
 )
 
-// recordingSink appends to the manager's master list, bumps sequence, and notifies subscribers.
+// recordingSink records to the manager's latest-state store and history
+// ring, bumps the sequence number, and notifies subscribers.
 type recordingSink struct {
 	mgr *eventManager
 }

--- a/internal/events/recording_sink.go
+++ b/internal/events/recording_sink.go
@@ -29,9 +29,9 @@ func (r *recordingSink) Receive(resType events.ResourceType, op events.Operation
 	}
 
 	r.mgr.mu.Lock()
-	_ = r.mgr.masterList.Receive(resType, op, resourceId, objects...)
+	r.mgr.latestState.Receive(resType, op, resourceId, objects...)
 	r.mgr.sequenceNumber++
-	r.mgr.storedEvents = append(r.mgr.storedEvents, events.NewStoredEvent(
+	r.mgr.historyTail.Add(events.NewStoredEvent(
 		r.mgr.sequenceNumber, time.Now(), resType, op, resourceId, objects,
 	))
 	subs := make([]events.Subscriber, len(r.mgr.subscribers))

--- a/modelsrv.code-workspace
+++ b/modelsrv.code-workspace
@@ -1,0 +1,25 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../book"
+		},
+		{
+			"path": "../go-emeland-io-website"
+		},
+		{
+			"path": "../modelsrv-k8s-sensor"
+		},
+		{
+			"path": "../emeland-demo-stack-chart"
+		},
+		{
+			"path": "../timadorus-platform"
+		}
+	],
+	"settings": {
+		"makefile.configureOnOpen": false
+	}
+}

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -22,6 +22,22 @@ import (
 	"go.emeland.io/modelsrv/pkg/model"
 )
 
+// config holds construction-time settings for New.
+type config struct {
+	eventHistoryLimit int
+}
+
+// Option configures a Backend at construction time.
+type Option func(*config)
+
+// WithEventHistoryLimit sets how many recent events the event manager's
+// history-query API can serve exactly; see eventmgr.WithHistoryLimit for
+// what happens to queries reaching further back. n must be positive or it
+// is ignored (the event manager's own default applies).
+func WithEventHistoryLimit(n int) Option {
+	return func(c *config) { c.eventHistoryLimit = n }
+}
+
 // Backend bundles the model, the filter chain, and the event manager.
 // External consumers (sensors, the web endpoint) retrieve only the part they need.
 type Backend interface {
@@ -50,8 +66,17 @@ type backendData struct {
 // The returned Backend has an empty filter chain; callers register their
 // [eventfilter.FilterFunc]s via [Backend.GetChain].Register before feeding
 // events into the model.
-func New() (Backend, error) {
-	eventMgr, err := eventmgr.NewEventManager()
+func New(opts ...Option) (Backend, error) {
+	cfg := config{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	var mgrOpts []eventmgr.Option
+	if cfg.eventHistoryLimit > 0 {
+		mgrOpts = append(mgrOpts, eventmgr.WithHistoryLimit(cfg.eventHistoryLimit))
+	}
+	eventMgr, err := eventmgr.NewEventManager(mgrOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -75,6 +75,28 @@ var _ = Describe("Backend", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(rules)).To(BeNumerically(">=", 2))
 		})
+
+		It("propagates WithEventHistoryLimit down to the event manager's history retention", func() {
+			b, err := backend.New(backend.WithEventHistoryLimit(2))
+			Expect(err).NotTo(HaveOccurred())
+
+			sink, err := b.GetEventManager().GetSink()
+			Expect(err).NotTo(HaveOccurred())
+
+			idA := uuid.New()
+			idB := uuid.New()
+			idC := uuid.New()
+			Expect(sink.Receive(events.SystemResource, events.CreateOperation, idA, "a1")).To(Succeed())
+			Expect(sink.Receive(events.SystemResource, events.CreateOperation, idB, "b1")).To(Succeed())
+			Expect(sink.Receive(events.SystemResource, events.CreateOperation, idC, "c1")).To(Succeed())
+
+			rt := events.SystemResource
+			results, err := b.GetEventManager().QueryEvents(context.Background(), events.EventQuery{ResourceType: &rt, IncludePayload: true})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(HaveLen(3))
+			Expect(results[0].ResourceId).To(Equal(idA))
+			Expect(results[0].Objects).To(Equal([]any{"a1"}))
+		})
 	})
 
 	Describe("wiring: model mutations flow through the filter chain", func() {

--- a/pkg/events/history.go
+++ b/pkg/events/history.go
@@ -36,6 +36,22 @@ func NewStoredEvent(seq uint64, ts time.Time, rt ResourceType, op Operation, id 
 // for resources that aged out of the window but still exist is synthesized
 // as a Create carrying their current state, so replaying the full result in
 // order reconstructs the same state a new subscriber would receive.
+//
+// The synthesized prefix is always delivered in full within a single
+// response, even if that means returning more than Limit entries: capping
+// it would let a paginating client (using the last returned SequenceId as
+// the next SinceSeq) permanently skip whatever didn't fit. Once a client's
+// SinceSeq reaches the retention boundary, subsequent calls page through
+// the retained tail normally, honoring Limit.
+//
+// Operation/ResourceType/ResourceId filters apply to the synthesized
+// prefix too, but the prefix only ever reports Operation "Create" — an
+// Operation filter for "Update" or "Delete" will not surface resources
+// whose only remaining history is synthesized, even if their real
+// historical operation was different. This is inherent to bounding
+// retention: preserving exact historical operation types forever would
+// require unbounded memory, which is what this retention window exists to
+// avoid.
 type EventQuery struct {
 	Operation      *Operation
 	ResourceType   *ResourceType

--- a/pkg/events/history.go
+++ b/pkg/events/history.go
@@ -30,6 +30,12 @@ func NewStoredEvent(seq uint64, ts time.Time, rt ResourceType, op Operation, id 
 }
 
 // EventQuery defines filters and pagination for querying event history.
+//
+// SinceSeq queries reaching further back than the EventManager's configured
+// retention window (see eventmgr.WithHistoryLimit) still succeed: history
+// for resources that aged out of the window but still exist is synthesized
+// as a Create carrying their current state, so replaying the full result in
+// order reconstructs the same state a new subscriber would receive.
 type EventQuery struct {
 	Operation      *Operation
 	ResourceType   *ResourceType

--- a/test/loadscale/load_scale_test.go
+++ b/test/loadscale/load_scale_test.go
@@ -1,0 +1,545 @@
+//go:build load_n_scale
+
+// Package loadscale_test exercises modelsrv with large numbers of resources and
+// changes, to observe how memory consumption grows.
+//
+// It is gated behind the "load_n_scale" build tag (Go build constraints do not
+// allow hyphens, so "load-n-scale" is not a valid tag name) so it never runs as
+// part of the normal test suite; invoke it explicitly via `make test-load-scale`.
+package loadscale_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"go.emeland.io/modelsrv/pkg/backend"
+	"go.emeland.io/modelsrv/pkg/model"
+	mdlapi "go.emeland.io/modelsrv/pkg/model/api"
+	"go.emeland.io/modelsrv/pkg/model/artifact"
+	mdlcapability "go.emeland.io/modelsrv/pkg/model/capability"
+	mdlcap "go.emeland.io/modelsrv/pkg/model/capacity"
+	"go.emeland.io/modelsrv/pkg/model/component"
+	mdlctx "go.emeland.io/modelsrv/pkg/model/context"
+	"go.emeland.io/modelsrv/pkg/model/finding"
+	"go.emeland.io/modelsrv/pkg/model/iam"
+	"go.emeland.io/modelsrv/pkg/model/node"
+	mdlparameter "go.emeland.io/modelsrv/pkg/model/parameter"
+	mdlproduct "go.emeland.io/modelsrv/pkg/model/product"
+	"go.emeland.io/modelsrv/pkg/model/system"
+)
+
+// Environment variables used to configure the test. Each *_COUNTS variable
+// takes a comma-separated list of positive integers, sorted least to
+// greatest (e.g. "10,100,1000").
+const (
+	envInstanceCounts = "LOAD_SCALE_INSTANCE_COUNTS"
+	envChangeCounts   = "LOAD_SCALE_CHANGE_COUNTS"
+	envReportPath     = "LOAD_SCALE_REPORT_PATH"
+
+	defaultInstanceCounts = "10,100,1000"
+	defaultChangeCounts   = "10,100,1000"
+	defaultReportPath     = "load_scale_report.md"
+)
+
+// parseCountList reads a comma-separated list of positive integers from the
+// given environment variable (or defaultCSV if unset), and requires the
+// values to be sorted least to greatest.
+func parseCountList(t *testing.T, envVar, defaultCSV string) []int {
+	t.Helper()
+
+	raw := os.Getenv(envVar)
+	if raw == "" {
+		raw = defaultCSV
+	}
+
+	var counts []int
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			t.Fatalf("%s: invalid integer %q: %v", envVar, part, err)
+		}
+		if n <= 0 {
+			t.Fatalf("%s: values must be positive, got %d", envVar, n)
+		}
+		counts = append(counts, n)
+	}
+
+	if len(counts) == 0 {
+		t.Fatalf("%s: at least one value is required", envVar)
+	}
+	if !sort.IntsAreSorted(counts) {
+		t.Fatalf("%s: values must be sorted least to greatest, got %v", envVar, counts)
+	}
+	return counts
+}
+
+// loadScaleCapacityContextNamespace deterministically derives a per-Capacity-instance
+// Context id from the Capacity's own id (see the "Capacity" resourceKind below).
+var loadScaleCapacityContextNamespace = uuid.MustParse("c9f3a1b2-6d4e-4a7f-9b1c-2e3d4f5a6b7c")
+
+// fixtureIDs are the ids of a single, shared set of prerequisite resources
+// that every generated instance may reference. Using one fixed set (rather
+// than cross-referencing other generated instances) keeps every resource
+// kind's scaling independent of the others and avoids creation-order
+// dependencies between kinds.
+type fixtureIDs struct {
+	contextType          uuid.UUID
+	context              uuid.UUID
+	system               uuid.UUID
+	nodeType             uuid.UUID
+	findingType          uuid.UUID
+	orgUnit              uuid.UUID
+	group                uuid.UUID
+	permissionSpec       uuid.UUID
+	roleSpec             uuid.UUID
+	permission           uuid.UUID
+	role                 uuid.UUID
+	api                  uuid.UUID
+	component            uuid.UUID
+	capacityResourceType uuid.UUID
+}
+
+// setupFixtures creates one instance of every resource kind that other
+// generated resources reference, and returns their ids.
+func setupFixtures(t *testing.T, m model.Model) fixtureIDs {
+	t.Helper()
+
+	f := fixtureIDs{
+		contextType:          uuid.New(),
+		context:              uuid.New(),
+		system:               uuid.New(),
+		nodeType:             uuid.New(),
+		findingType:          uuid.New(),
+		orgUnit:              uuid.New(),
+		group:                uuid.New(),
+		permissionSpec:       uuid.New(),
+		roleSpec:             uuid.New(),
+		permission:           uuid.New(),
+		role:                 uuid.New(),
+		api:                  uuid.New(),
+		component:            uuid.New(),
+		capacityResourceType: uuid.New(),
+	}
+
+	ct := mdlctx.NewContextType(f.contextType)
+	ct.SetDisplayName("fixture ContextType")
+	require.NoError(t, m.AddContextType(ct))
+
+	c := mdlctx.NewContext(f.context)
+	c.SetDisplayName("fixture Context")
+	c.SetContextTypeById(f.contextType)
+	require.NoError(t, m.AddContext(c))
+
+	sys := system.NewSystem(f.system)
+	sys.SetDisplayName("fixture System")
+	require.NoError(t, m.AddSystem(sys))
+
+	nt := node.NewNodeType(f.nodeType)
+	nt.SetDisplayName("fixture NodeType")
+	require.NoError(t, m.AddNodeType(nt))
+
+	ft := finding.NewFindingType(f.findingType)
+	ft.SetDisplayName("fixture FindingType")
+	require.NoError(t, m.AddFindingType(ft))
+
+	ou := iam.NewOrgUnit(f.orgUnit)
+	ou.SetDisplayName("fixture OrgUnit")
+	require.NoError(t, m.AddOrgUnit(ou))
+
+	g := iam.NewGroup(f.group)
+	g.SetDisplayName("fixture Group")
+	require.NoError(t, m.AddGroup(g))
+
+	ps := iam.NewPermissionSpec(f.permissionSpec)
+	ps.SetDisplayName("fixture PermissionSpec")
+	require.NoError(t, m.AddPermissionSpec(ps))
+
+	rs := iam.NewRoleSpec(f.roleSpec)
+	rs.SetDisplayName("fixture RoleSpec")
+	rs.SetPermissions([]*iam.PermissionSpecRef{{PermissionSpecId: f.permissionSpec}})
+	require.NoError(t, m.AddRoleSpec(rs))
+
+	p := iam.NewPermission(f.permission)
+	p.SetDisplayName("fixture Permission")
+	p.SetPermissionSpecById(f.permissionSpec)
+	require.NoError(t, m.AddPermission(p))
+
+	r := iam.NewRole(f.role)
+	r.SetDisplayName("fixture Role")
+	r.SetRoleSpecById(f.roleSpec)
+	r.SetContextRef(&mdlctx.ContextRef{ContextId: f.context})
+	r.SetPermissions([]*iam.PermissionRef{{PermissionId: f.permission}})
+	require.NoError(t, m.AddRole(r))
+
+	a := mdlapi.NewAPI(f.api)
+	a.SetDisplayName("fixture API")
+	a.SetSystem(&system.SystemRef{SystemId: f.system})
+	require.NoError(t, m.AddApi(a))
+
+	comp := component.NewComponent(f.component)
+	comp.SetDisplayName("fixture Component")
+	comp.SetSystem(&system.SystemRef{SystemId: f.system})
+	require.NoError(t, m.AddComponent(comp))
+
+	crt := mdlcap.NewCapacityResourceType(f.capacityResourceType)
+	crt.SetDisplayName("fixture CapacityResourceType")
+	crt.SetUnit("cores")
+	require.NoError(t, m.AddCapacityResourceType(crt))
+
+	return f
+}
+
+// resourceKind pairs a human-readable name with a function that creates or
+// updates (depending on whether id already exists in the model) one instance
+// of that resource kind.
+type resourceKind struct {
+	Name  string
+	Apply func(m model.Model, id uuid.UUID, displayName string) error
+}
+
+// resourceKinds returns every resource kind defined by
+// [go.emeland.io/modelsrv/pkg/events.ResourceType], excluding
+// FilterRuleResource, MergeRuleResource, and AnnotationsResource (which are
+// pipeline-visibility / value-object kinds rather than model resources), and
+// UnknownResourceType.
+func resourceKinds(f fixtureIDs) []resourceKind {
+	return []resourceKind{
+		{"Node", func(m model.Model, id uuid.UUID, dn string) error {
+			n := node.NewNode(id)
+			n.SetDisplayName(dn)
+			n.SetTypeRef(&node.NodeTypeRef{NodeTypeId: f.nodeType})
+			return m.AddNode(n)
+		}},
+		{"NodeType", func(m model.Model, id uuid.UUID, dn string) error {
+			nt := node.NewNodeType(id)
+			nt.SetDisplayName(dn)
+			return m.AddNodeType(nt)
+		}},
+		{"Context", func(m model.Model, id uuid.UUID, dn string) error {
+			c := mdlctx.NewContext(id)
+			c.SetDisplayName(dn)
+			c.SetContextTypeById(f.contextType)
+			return m.AddContext(c)
+		}},
+		{"ContextType", func(m model.Model, id uuid.UUID, dn string) error {
+			ct := mdlctx.NewContextType(id)
+			ct.SetDisplayName(dn)
+			return m.AddContextType(ct)
+		}},
+		{"System", func(m model.Model, id uuid.UUID, dn string) error {
+			sys := system.NewSystem(id)
+			sys.SetDisplayName(dn)
+			return m.AddSystem(sys)
+		}},
+		{"SystemInstance", func(m model.Model, id uuid.UUID, dn string) error {
+			si := system.NewSystemInstance(id)
+			si.SetDisplayName(dn)
+			si.SetSystemRef(&system.SystemRef{SystemId: f.system})
+			return m.AddSystemInstance(si)
+		}},
+		{"API", func(m model.Model, id uuid.UUID, dn string) error {
+			a := mdlapi.NewAPI(id)
+			a.SetDisplayName(dn)
+			a.SetSystem(&system.SystemRef{SystemId: f.system})
+			return m.AddApi(a)
+		}},
+		{"APIInstance", func(m model.Model, id uuid.UUID, dn string) error {
+			ai := mdlapi.NewApiInstance(id)
+			ai.SetDisplayName(dn)
+			ai.SetApiRef(&mdlapi.ApiRef{ApiID: f.api})
+			return m.AddApiInstance(ai)
+		}},
+		{"Component", func(m model.Model, id uuid.UUID, dn string) error {
+			comp := component.NewComponent(id)
+			comp.SetDisplayName(dn)
+			comp.SetSystem(&system.SystemRef{SystemId: f.system})
+			return m.AddComponent(comp)
+		}},
+		{"ComponentInstance", func(m model.Model, id uuid.UUID, dn string) error {
+			ci := component.NewComponentInstance(id)
+			ci.SetDisplayName(dn)
+			ci.SetComponentRef(&component.ComponentRef{ComponentId: f.component})
+			return m.AddComponentInstance(ci)
+		}},
+		{"OrgUnit", func(m model.Model, id uuid.UUID, dn string) error {
+			ou := iam.NewOrgUnit(id)
+			ou.SetDisplayName(dn)
+			return m.AddOrgUnit(ou)
+		}},
+		{"Group", func(m model.Model, id uuid.UUID, dn string) error {
+			g := iam.NewGroup(id)
+			g.SetDisplayName(dn)
+			return m.AddGroup(g)
+		}},
+		{"Identity", func(m model.Model, id uuid.UUID, dn string) error {
+			idy := iam.NewIdentity(id)
+			idy.SetDisplayName(dn)
+			return m.AddIdentity(idy)
+		}},
+		{"PermissionSpec", func(m model.Model, id uuid.UUID, dn string) error {
+			ps := iam.NewPermissionSpec(id)
+			ps.SetDisplayName(dn)
+			return m.AddPermissionSpec(ps)
+		}},
+		{"RoleSpec", func(m model.Model, id uuid.UUID, dn string) error {
+			rs := iam.NewRoleSpec(id)
+			rs.SetDisplayName(dn)
+			rs.SetPermissions([]*iam.PermissionSpecRef{{PermissionSpecId: f.permissionSpec}})
+			return m.AddRoleSpec(rs)
+		}},
+		{"Permission", func(m model.Model, id uuid.UUID, dn string) error {
+			p := iam.NewPermission(id)
+			p.SetDisplayName(dn)
+			p.SetPermissionSpecById(f.permissionSpec)
+			return m.AddPermission(p)
+		}},
+		{"Role", func(m model.Model, id uuid.UUID, dn string) error {
+			r := iam.NewRole(id)
+			r.SetDisplayName(dn)
+			r.SetRoleSpecById(f.roleSpec)
+			r.SetContextRef(&mdlctx.ContextRef{ContextId: f.context})
+			r.SetPermissions([]*iam.PermissionRef{{PermissionId: f.permission}})
+			return m.AddRole(r)
+		}},
+		{"Binding", func(m model.Model, id uuid.UUID, dn string) error {
+			b := iam.NewBinding(id)
+			b.SetDisplayName(dn)
+			b.SetRole(&iam.RoleRef{RoleId: f.role})
+			b.SetSubject(&iam.SubjectRef{Group: &iam.GroupRef{GroupId: f.group}})
+			return m.AddBinding(b)
+		}},
+		{"Product", func(m model.Model, id uuid.UUID, dn string) error {
+			p := mdlproduct.NewProduct(id)
+			p.SetDisplayName(dn)
+			p.SetVendor(&iam.OrgUnitRef{OrgUnitId: f.orgUnit})
+			return m.AddProduct(p)
+		}},
+		{"Finding", func(m model.Model, id uuid.UUID, dn string) error {
+			fnd := finding.NewFinding(id)
+			fnd.SetDisplayName(dn)
+			fnd.SetFindingTypeById(f.findingType)
+			return m.AddFinding(fnd)
+		}},
+		{"FindingType", func(m model.Model, id uuid.UUID, dn string) error {
+			ft := finding.NewFindingType(id)
+			ft.SetDisplayName(dn)
+			return m.AddFindingType(ft)
+		}},
+		{"Artifact", func(m model.Model, id uuid.UUID, dn string) error {
+			a := artifact.NewArtifact(id)
+			a.SetDisplayName(dn)
+			return m.AddArtifact(a)
+		}},
+		{"ArtifactInstance", func(m model.Model, id uuid.UUID, dn string) error {
+			ai := artifact.NewArtifactInstance(id)
+			ai.SetDisplayName(dn)
+			return m.AddArtifactInstance(ai)
+		}},
+		{"Capability", func(m model.Model, id uuid.UUID, dn string) error {
+			cap := mdlcapability.NewCapability(id)
+			cap.SetDisplayName(dn)
+			return m.AddCapability(cap)
+		}},
+		{"Parameter", func(m model.Model, id uuid.UUID, dn string) error {
+			param := mdlparameter.NewParameter(id)
+			param.SetDisplayName(dn)
+			param.SetValues([]string{"val1", "val2"})
+			return m.AddParameter(param)
+		}},
+		{"CapacityResourceType", func(m model.Model, id uuid.UUID, dn string) error {
+			crt := mdlcap.NewCapacityResourceType(id)
+			crt.SetDisplayName(dn)
+			crt.SetUnit("cores")
+			return m.AddCapacityResourceType(crt)
+		}},
+		{"Capacity", func(m model.Model, id uuid.UUID, dn string) error {
+			// Capacity uniqueness is (contextId, capacityResourceTypeId, category), not id alone
+			// (see pkg/model/structure_capacity.go), so each instance needs its own Context;
+			// reusing the shared fixture Context would collide after the first instance.
+			ctxID := uuid.NewSHA1(loadScaleCapacityContextNamespace, id[:])
+			if m.GetContextById(ctxID) == nil {
+				ctx := mdlctx.NewContext(ctxID)
+				ctx.SetDisplayName("capacity-context-" + id.String())
+				ctx.SetContextTypeById(f.contextType)
+				if err := m.AddContext(ctx); err != nil {
+					return err
+				}
+			}
+			cap := mdlcap.NewCapacity(id)
+			cap.SetDisplayName(dn)
+			cap.SetCapacityResourceTypeById(f.capacityResourceType)
+			cap.SetContextById(ctxID)
+			cap.SetCategory(mdlcap.CategoryProvided)
+			cap.SetAmount(mdlcap.Amount("64"))
+			return m.AddCapacity(cap)
+		}},
+	}
+}
+
+// loadResult captures the outcome of a single (instances, changes) combination.
+type loadResult struct {
+	Instances        int
+	Changes          int
+	TotalEvents      int
+	Duration         time.Duration
+	HeapAllocBefore  uint64
+	HeapAllocAfter   uint64
+	TotalAllocDelta  uint64
+	HeapObjectsAfter uint64
+}
+
+// TestLoadScale builds, for every (instances, changes) combination in the
+// configured lists, a fresh production-wired backend (Model + EventManager),
+// creates `instances` instances of every resource kind (see resourceKinds),
+// and applies `changes` total Create/Update operations to each instance (the
+// first operation is the Create, the rest are Updates). It measures process
+// memory before and after each combination and writes a markdown report.
+func TestLoadScale(t *testing.T) {
+	instanceCounts := parseCountList(t, envInstanceCounts, defaultInstanceCounts)
+	changeCounts := parseCountList(t, envChangeCounts, defaultChangeCounts)
+
+	reportPath := os.Getenv(envReportPath)
+	if reportPath == "" {
+		reportPath = defaultReportPath
+	}
+
+	kindCount := len(resourceKinds(fixtureIDs{}))
+
+	var results []loadResult
+
+	for _, instances := range instanceCounts {
+		for _, changes := range changeCounts {
+			t.Run(fmt.Sprintf("instances=%d/changes=%d", instances, changes), func(t *testing.T) {
+				totalEvents := kindCount * instances * changes
+				t.Logf("building %d resource kinds x %d instances x %d changes = %d events", kindCount, instances, changes, totalEvents)
+
+				runtime.GC()
+				var before runtime.MemStats
+				runtime.ReadMemStats(&before)
+
+				start := time.Now()
+
+				b, err := backend.New()
+				require.NoError(t, err)
+				m := b.GetModel()
+				f := setupFixtures(t, m)
+
+				for _, kind := range resourceKinds(f) {
+					for i := 0; i < instances; i++ {
+						id := uuid.New()
+						for c := 0; c < changes; c++ {
+							dn := fmt.Sprintf("%s-%d-change-%d", kind.Name, i, c)
+							require.NoErrorf(t, kind.Apply(m, id, dn), "%s instance %d change %d", kind.Name, i, c)
+						}
+					}
+				}
+
+				elapsed := time.Since(start)
+
+				runtime.GC()
+				var after runtime.MemStats
+				runtime.ReadMemStats(&after)
+				runtime.KeepAlive(b)
+
+				results = append(results, loadResult{
+					Instances:        instances,
+					Changes:          changes,
+					TotalEvents:      totalEvents,
+					Duration:         elapsed,
+					HeapAllocBefore:  before.HeapAlloc,
+					HeapAllocAfter:   after.HeapAlloc,
+					TotalAllocDelta:  after.TotalAlloc - before.TotalAlloc,
+					HeapObjectsAfter: after.HeapObjects,
+				})
+
+				t.Logf("instances=%d changes=%d: heap alloc after=%s (delta %s), duration=%s",
+					instances, changes, formatBytes(after.HeapAlloc), formatSignedBytes(int64(after.HeapAlloc)-int64(before.HeapAlloc)), elapsed.Round(time.Millisecond))
+			})
+		}
+	}
+
+	writeReport(t, reportPath, kindCount, instanceCounts, changeCounts, results)
+}
+
+func writeReport(t *testing.T, path string, kindCount int, instanceCounts, changeCounts []int, results []loadResult) {
+	t.Helper()
+
+	var sb strings.Builder
+
+	sb.WriteString("# modelsrv Load & Scale Report\n\n")
+	fmt.Fprintf(&sb, "Generated: %s\n\n", time.Now().Format(time.RFC3339))
+	fmt.Fprintf(&sb, "Go runtime: %s, GOMAXPROCS: %d\n\n", runtime.Version(), runtime.GOMAXPROCS(0))
+	fmt.Fprintf(&sb, "Resource kinds exercised per combination: **%d** "+
+		"(every `pkg/events.ResourceType` except `UnknownResourceType`, `FilterRuleResource`, "+
+		"`MergeRuleResource`, and `AnnotationsResource`).\n\n", kindCount)
+	fmt.Fprintf(&sb, "Instance counts (`%s`): %v\n\n", envInstanceCounts, instanceCounts)
+	fmt.Fprintf(&sb, "Change counts (`%s`): %v\n\n", envChangeCounts, changeCounts)
+	sb.WriteString("Each row builds a fresh `backend.Backend` (the same `Model` + `EventManager` wiring " +
+		"modelsrv uses in production, including the in-memory event history kept for replication). " +
+		"For every resource kind it creates N instances and applies C total Create/Update operations " +
+		"to each instance (the first operation is the Create, the remaining C-1 are Updates), so " +
+		"`Total Events` = resource kinds × instances × changes. Memory is sampled with " +
+		"`runtime.ReadMemStats` immediately after a forced `runtime.GC()`, once before and once after " +
+		"the run.\n\n")
+
+	sb.WriteString("| Instances/Resource | Changes/Instance | Total Events | Duration | Heap Alloc (after) | Heap Alloc Δ | Total Alloc (churn) | Heap Objects (after) |\n")
+	sb.WriteString("|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+	for _, r := range results {
+		delta := int64(r.HeapAllocAfter) - int64(r.HeapAllocBefore)
+		fmt.Fprintf(&sb, "| %d | %d | %d | %s | %s | %s | %s | %d |\n",
+			r.Instances, r.Changes, r.TotalEvents, r.Duration.Round(time.Millisecond),
+			formatBytes(r.HeapAllocAfter), formatSignedBytes(delta),
+			formatBytes(r.TotalAllocDelta), r.HeapObjectsAfter)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(abs(path)), 0o755); err != nil {
+		t.Fatalf("creating report directory for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
+		t.Fatalf("writing report to %s: %v", path, err)
+	}
+	t.Logf("load-scale report written to %s", path)
+}
+
+// abs returns path made absolute against the current working directory,
+// falling back to path itself if that fails (e.g. an already-absolute path).
+func abs(path string) string {
+	if a, err := filepath.Abs(path); err == nil {
+		return a
+	}
+	return path
+}
+
+func formatBytes(b uint64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := uint64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.2f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+func formatSignedBytes(b int64) string {
+	if b < 0 {
+		return "-" + formatBytes(uint64(-b))
+	}
+	return formatBytes(uint64(b))
+}


### PR DESCRIPTION
This branch adds code to ensure the memory consumption of the model server only scales with the number of resources in the model, not with the observed update events after a configurable of maintained history.

- a test in `test/loadscale/` and a Makefile target to call it, which will create an increasing set of resources from each resource type and an perform increasing sets of changes on each resource created. 
  The amount of heap memory required will be written to markdown report

- a change to the way changes are tracked, so that always a) the current state of all resources is available to be sent to a new subscriber and b) a history of configurable size (default: 1000) with all older changes compacted into a set of resources to reflect the model state at that point in time.