### PR TITLE
feat: write output to stdout with -o -

### DIFF
--- a/cmd/emelandctl/resource.go
+++ b/cmd/emelandctl/resource.go
@@ -116,11 +116,17 @@ func registerResourceCmd(createCmd *cobra.Command, def resourceDef, outputDir, o
 }
 
 // writeResource marshals a Resource to YAML and writes it to the path
-// determined by outputFile or outputDir.
+// determined by outputFile or outputDir. If outputFile is "-", the YAML is
+// written to standard output.
 func writeResource(r Resource, id uuid.UUID, outputDir, outputFile string) error {
 	data, err := yaml.Marshal(r)
 	if err != nil {
 		return fmt.Errorf("marshalling YAML: %w", err)
+	}
+
+	if outputFile == "-" {
+		_, err := os.Stdout.Write(data)
+		return err
 	}
 
 	filename := outputFile

--- a/cmd/emelandctl/resource_test.go
+++ b/cmd/emelandctl/resource_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -171,6 +172,33 @@ func TestCreateWithOutputFlag(t *testing.T) {
 	require.NoError(t, yaml.Unmarshal(data, &r))
 	assert.Equal(t, "System", r.Kind)
 	assert.Equal(t, "My System", r.Spec["displayName"])
+}
+
+func TestCreateWritesToStdout(t *testing.T) {
+	// Capture stdout by replacing os.Stdout with a pipe.
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	execErr := executeCmd("create", "-o", "-", "system", "Stdout System")
+
+	_ = w.Close()
+	os.Stdout = origStdout
+
+	require.NoError(t, execErr)
+
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	var res Resource
+	require.NoError(t, yaml.Unmarshal(output, &res))
+	assert.Equal(t, "System", res.Kind)
+	assert.Equal(t, "Stdout System", res.Spec["displayName"])
+	assert.NotEmpty(t, res.Spec["systemId"])
+
+	// Ensure no "Created ..." message is mixed into the output.
+	assert.NotContains(t, string(output), "Created")
 }
 
 func TestCreateFailsWithInvalidResourceType(t *testing.T) {


### PR DESCRIPTION
When the user passes `-` as the output file argument (`-o -`), the created resource YAML is written to standard output instead of a file. The status message is suppressed in this mode to keep stdout clean for piping.

**Changes:**
- `resource.go`: handle `outputFile == "-"` by writing to stdout
- `resource_test.go`: add `TestCreateWritesToStdout`

Closes #155