### PR TITLE
Resolve MissingResourceReference findings for SystemInstance

### DIFF
--- a/pkg/eventfilter/resolvefindings/resolvefindings.go
+++ b/pkg/eventfilter/resolvefindings/resolvefindings.go
@@ -222,6 +222,13 @@ func subjectHasRequiredRef(m model.Model, subject *common.ResourceRef) bool {
 		}
 		ref := ci.GetComponentRef()
 		return ref != nil && ref.ComponentId != uuid.Nil
+	case events.SystemInstanceResource:
+		si := m.GetSystemInstanceById(subject.ResourceId)
+		if si == nil {
+			return false
+		}
+		ref := si.GetSystemRef()
+		return ref != nil && ref.SystemId != uuid.Nil
 	default:
 		return false
 	}

--- a/pkg/eventfilter/resolvefindings/resolvefindings_test.go
+++ b/pkg/eventfilter/resolvefindings/resolvefindings_test.go
@@ -15,6 +15,7 @@ import (
 	"go.emeland.io/modelsrv/pkg/model/component"
 	mdlctx "go.emeland.io/modelsrv/pkg/model/context"
 	"go.emeland.io/modelsrv/pkg/model/finding"
+	"go.emeland.io/modelsrv/pkg/model/system"
 )
 
 func newModel() model.Model {
@@ -258,6 +259,31 @@ var _ = Describe("MissingResourceReference resolution", func() {
 		updated.SetDisplayName("job")
 		updated.SetComponentRef(&component.ComponentRef{ComponentId: uuid.New()})
 		Expect(m.AddComponentInstance(updated)).To(Succeed())
+
+		Expect(findingsOfKind(m, finding.MissingResourceReference)).To(BeEmpty())
+	})
+
+	It("clears when SystemInstance later gains a SystemRef", func() {
+		m, _ := newModelWithResolveChain()
+		siID := uuid.New()
+
+		si := system.NewSystemInstance(siID)
+		si.SetDisplayName("helm-release")
+		Expect(m.AddSystemInstance(si)).To(Succeed())
+
+		f := finding.NewFinding(uuid.New())
+		f.SetFindingTypeById(finding.TypeIDForKind(finding.MissingResourceReference))
+		f.SetDisplayName(string(finding.MissingResourceReference))
+		f.SetResources([]*common.ResourceRef{
+			{ResourceId: siID, ResourceType: events.SystemInstanceResource},
+		})
+		Expect(m.AddFinding(f)).To(Succeed())
+		Expect(findingsOfKind(m, finding.MissingResourceReference)).To(HaveLen(1))
+
+		updated := system.NewSystemInstance(siID)
+		updated.SetDisplayName("helm-release")
+		updated.SetSystemRef(&system.SystemRef{SystemId: uuid.New()})
+		Expect(m.AddSystemInstance(updated)).To(Succeed())
 
 		Expect(findingsOfKind(m, finding.MissingResourceReference)).To(BeEmpty())
 	})


### PR DESCRIPTION
When a SystemInstance gains a SystemRef (e.g. via annotation from the k8s sensor after the git sensor provides the System), delete the MissingResourceReference finding. Same pattern as ApiInstance/ComponentInstance.

Closes #156