### PR TITLE
Inject caller logger into web endpoint

### DIFF
--- a/cmd/modelsrv/server.go
+++ b/cmd/modelsrv/server.go
@@ -144,6 +144,7 @@ func runServer(cmd *cobra.Command, _ []string) error {
 			AuditorGroup:    auditorGroup,
 			PublicTypes:     authz.ParsePublicResourceTypes(publicResourceTypes),
 		},
+		Logger: logger,
 	}
 	if err := endpoint.StartWebListener(b.GetModel(), b.GetEventManager(), serviceAddr, webOpts); err != nil {
 		return fmt.Errorf("starting web listener: %w", err)

--- a/pkg/endpoint/web_endpoint.go
+++ b/pkg/endpoint/web_endpoint.go
@@ -27,6 +27,9 @@ import (
 type WebListenerOptions struct {
 	TrustAuthHeaders bool
 	AuthzConfig      authz.Config
+	// Logger is used for endpoint lifecycle messages and HTTP request logging.
+	// When nil, a no-op logger is used (no output).
+	Logger *zap.SugaredLogger
 }
 
 var (
@@ -34,9 +37,16 @@ var (
 	webListener    net.Listener
 	metricsServer  *http.Server
 	metricsHandler http.Handler
-	setupLog       zap.SugaredLogger
 	metricsReg     *prometheus.Registry
+	endpointLog    *zap.SugaredLogger // set by StartWebListener; used by Stop/Metrics helpers
 )
+
+func ensureLogger(log *zap.SugaredLogger) *zap.SugaredLogger {
+	if log != nil {
+		return log
+	}
+	return zap.NewNop().Sugar()
+}
 
 // NewHandler builds the modelsrv HTTP handler (API + swagger + metrics) without
 // starting a listener. The caller is responsible for serving it on their own
@@ -46,6 +56,8 @@ var (
 // Note: StartMetricsListener is not compatible with NewHandler; it only works
 // with StartWebListener which manages its own server lifecycle.
 func NewHandler(backend model.Model, eventMgr events.EventManager, baseURL string, opts WebListenerOptions) http.Handler {
+	log := ensureLogger(opts.Logger)
+
 	var authzEval *authz.Evaluator
 	if opts.TrustAuthHeaders {
 		authzEval = authz.NewEvaluator(opts.AuthzConfig)
@@ -60,7 +72,7 @@ func NewHandler(backend model.Model, eventMgr events.EventManager, baseURL strin
 	r := mux.NewRouter()
 	r.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 
-	spa := spaHandler{staticPath: "/", indexPath: "/swagger/index.html"}
+	spa := spaHandler{staticPath: "/", indexPath: "/swagger/index.html", log: log}
 	r.PathPrefix("/swagger").Handler(spa)
 	r.HandleFunc("/api/events/history", server.HandleGetEventsHistory).Methods("GET")
 
@@ -72,7 +84,8 @@ func NewHandler(backend model.Model, eventMgr events.EventManager, baseURL strin
 //
 // addr is the address and port to bind to, e.g. "localhost:24000"
 func StartWebListener(backend model.Model, eventMgr events.EventManager, addr string, opts WebListenerOptions) error {
-	setupLog = *zap.NewExample().Sugar()
+	log := ensureLogger(opts.Logger)
+	endpointLog = log
 
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -99,13 +112,13 @@ func StartWebListener(backend model.Model, eventMgr events.EventManager, addr st
 		metricsHandler.ServeHTTP(w, req)
 	}))
 
-	spa := spaHandler{staticPath: "/", indexPath: "/swagger/index.html"}
+	spa := spaHandler{staticPath: "/", indexPath: "/swagger/index.html", log: log}
 	r.PathPrefix("/swagger").Handler(spa)
 	r.HandleFunc("/api/events/history", server.HandleGetEventsHistory).Methods("GET")
 
 	h := oapi.HandlerFromMuxWithBaseURL(strict, r, "/api")
 
-	setupLog.Info("Starting Web-Endpoint: ", "address: ", ln.Addr().String())
+	log.Infow("starting web endpoint", "address", ln.Addr().String())
 
 	webServer = &http.Server{
 		Handler: h,
@@ -114,7 +127,7 @@ func StartWebListener(backend model.Model, eventMgr events.EventManager, addr st
 	srv := webServer
 	go func() {
 		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
-			setupLog.Error(err, ". Ended server with error")
+			log.Errorw("web server ended with error", "error", err)
 		}
 	}()
 
@@ -122,16 +135,17 @@ func StartWebListener(backend model.Model, eventMgr events.EventManager, addr st
 }
 
 func StopWebListener() {
+	log := ensureLogger(endpointLog)
 	if metricsServer != nil {
 		if err := metricsServer.Shutdown(context.Background()); err != nil {
-			setupLog.Error("Error shutting down metrics server: ", err)
+			log.Errorw("error shutting down metrics server", "error", err)
 		}
 	}
 	if webServer == nil {
 		return
 	}
 	if err := webServer.Shutdown(context.Background()); err != nil {
-		setupLog.Error("Error shutting down web server: ", err)
+		log.Errorw("error shutting down web server", "error", err)
 	}
 	webServer = nil
 	webListener = nil
@@ -150,6 +164,7 @@ func StartMetricsListener(addr string) error {
 	if metricsReg == nil {
 		return fmt.Errorf("metrics registry not initialized; call StartWebListener first")
 	}
+	log := ensureLogger(endpointLog)
 	metricsURL := fmt.Sprintf("http://%s/metrics", addr)
 	metricsHandler = http.RedirectHandler(metricsURL, http.StatusTemporaryRedirect)
 
@@ -158,10 +173,10 @@ func StartMetricsListener(addr string) error {
 	metricsServer = &http.Server{Handler: mux, Addr: addr}
 	go func() {
 		if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			setupLog.Error("metrics server: ", err)
+			log.Errorw("metrics server error", "error", err)
 		}
 	}()
-	setupLog.Info("Metrics endpoint: ", metricsURL)
+	log.Infow("metrics endpoint started", "url", metricsURL)
 	return nil
 }
 
@@ -181,6 +196,7 @@ func WebListenerAddr() net.Addr {
 type spaHandler struct {
 	staticPath string
 	indexPath  string
+	log        *zap.SugaredLogger
 }
 
 // ServeHTTP inspects the URL path to locate a file within the static dir
@@ -191,13 +207,13 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Join internally call path.Clean to prevent directory traversal
 	path := filepath.Join(h.staticPath, r.URL.Path)
 
-	setupLog.Info("SPA Handler called to service file", "path", path, "staticPath", h.staticPath, "URL path", r.URL.Path)
+	h.log.Debugw("serving static file", "path", path, "url", r.URL.Path)
 
 	// check whether a file exists or is a directory at the given path
 	fi, err := os.Stat(path)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			setupLog.Error("SPA Handler stat error", "path", path, "error", err)
+			h.log.Errorw("static file stat error", "path", path, "error", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
@@ -207,7 +223,6 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// fi is only non-nil when err == nil, so IsDir() is safe here.
 	if err != nil || fi.IsDir() {
 		path = filepath.Join(h.staticPath, h.indexPath)
-		setupLog.Info("SPA Handler will serve index file", "path", path)
 		http.ServeFile(w, r, path)
 		return
 	}

--- a/pkg/endpoint/web_endpoint_test.go
+++ b/pkg/endpoint/web_endpoint_test.go
@@ -6,6 +6,9 @@ import (
 	eventmgr "go.emeland.io/modelsrv/internal/events"
 	"go.emeland.io/modelsrv/pkg/events"
 	"go.emeland.io/modelsrv/pkg/model"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestStartUIListener(t *testing.T) {
@@ -31,4 +34,59 @@ func TestStartUIListener(t *testing.T) {
 		t.Fatal("expected non-nil listener address")
 	}
 	t.Logf("listening on %s", addr.String())
+}
+
+func TestStartWebListener_ObserverSeesStartLog(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core).Sugar()
+
+	sink := events.NewDummySink()
+	backend, err := model.NewModel(sink)
+	if err != nil {
+		t.Fatalf("failed to create model: %v", err)
+	}
+	eventMgr, err := eventmgr.NewEventManager()
+	if err != nil {
+		t.Fatalf("failed to create event manager: %v", err)
+	}
+
+	err = StartWebListener(backend, eventMgr, "127.0.0.1:0", WebListenerOptions{Logger: logger})
+	if err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	defer StopWebListener()
+
+	found := false
+	for _, entry := range logs.All() {
+		if entry.Message == "starting web endpoint" {
+			found = true
+			ctx := entry.ContextMap()
+			if _, ok := ctx["address"]; !ok {
+				t.Error("expected 'address' field in start log")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'starting web endpoint' log entry on observer")
+	}
+}
+
+func TestStartWebListener_NilLoggerNoOutput(t *testing.T) {
+	sink := events.NewDummySink()
+	backend, err := model.NewModel(sink)
+	if err != nil {
+		t.Fatalf("failed to create model: %v", err)
+	}
+	eventMgr, err := eventmgr.NewEventManager()
+	if err != nil {
+		t.Fatalf("failed to create event manager: %v", err)
+	}
+
+	// nil logger should not panic and produce no output
+	err = StartWebListener(backend, eventMgr, "127.0.0.1:0", WebListenerOptions{})
+	if err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	StopWebListener()
 }


### PR DESCRIPTION
Add Logger field to WebListenerOptions. Both NewHandler and StartWebListener use it for lifecycle messages (start, shutdown, errors). Nil logger falls back to no-op. Eliminates the package-global zap.NewExample() logger. SPA handler uses structured Debug logging instead of Info.

Closes #159