### PR TITLE
Add HTTP request logging middleware

### DIFF
--- a/pkg/endpoint/web_endpoint.go
+++ b/pkg/endpoint/web_endpoint.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
@@ -76,7 +78,7 @@ func NewHandler(backend model.Model, eventMgr events.EventManager, baseURL strin
 	r.PathPrefix("/swagger").Handler(spa)
 	r.HandleFunc("/api/events/history", server.HandleGetEventsHistory).Methods("GET")
 
-	return oapi.HandlerFromMuxWithBaseURL(strict, r, "/api")
+	return requestLoggingMiddleware(log)(oapi.HandlerFromMuxWithBaseURL(strict, r, "/api"))
 }
 
 // StartWebListener starts the web endpoint serving the Swagger-UI and API
@@ -121,7 +123,7 @@ func StartWebListener(backend model.Model, eventMgr events.EventManager, addr st
 	log.Infow("starting web endpoint", "address", ln.Addr().String())
 
 	webServer = &http.Server{
-		Handler: h,
+		Handler: requestLoggingMiddleware(log)(h),
 	}
 
 	srv := webServer
@@ -229,4 +231,43 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// otherwise, use http.FileServer to serve the static file
 	http.FileServer(http.Dir(h.staticPath)).ServeHTTP(w, r)
+}
+
+// requestLoggingMiddleware logs each HTTP request with method, path, status
+// code, and duration. API requests log at INFO (5xx at WARN). Infrastructure
+// paths (/metrics, /swagger) log at DEBUG to avoid noise.
+func requestLoggingMiddleware(log *zap.SugaredLogger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+			next.ServeHTTP(sw, r)
+			path := r.URL.Path
+			fields := []any{
+				"method", r.Method,
+				"path", path,
+				"status", sw.status,
+				"duration", time.Since(start).String(),
+			}
+			switch {
+			case strings.HasPrefix(path, "/metrics") || strings.HasPrefix(path, "/swagger"):
+				log.Debugw("http request", fields...)
+			case sw.status >= 500:
+				log.Warnw("http request", fields...)
+			default:
+				log.Infow("http request", fields...)
+			}
+		})
+	}
+}
+
+// statusWriter wraps http.ResponseWriter to capture the status code.
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *statusWriter) WriteHeader(code int) {
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
 }

--- a/pkg/endpoint/web_endpoint_test.go
+++ b/pkg/endpoint/web_endpoint_test.go
@@ -1,6 +1,8 @@
 package endpoint
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
 	eventmgr "go.emeland.io/modelsrv/internal/events"
@@ -83,10 +85,124 @@ func TestStartWebListener_NilLoggerNoOutput(t *testing.T) {
 		t.Fatalf("failed to create event manager: %v", err)
 	}
 
-	// nil logger should not panic and produce no output
 	err = StartWebListener(backend, eventMgr, "127.0.0.1:0", WebListenerOptions{})
 	if err != nil {
 		t.Fatalf("start failed: %v", err)
 	}
 	StopWebListener()
+}
+
+func TestRequestLogging_APICallEmitsInfoLog(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core).Sugar()
+
+	sink := events.NewDummySink()
+	backend, err := model.NewModel(sink)
+	if err != nil {
+		t.Fatalf("failed to create model: %v", err)
+	}
+	eventMgr, err := eventmgr.NewEventManager()
+	if err != nil {
+		t.Fatalf("failed to create event manager: %v", err)
+	}
+
+	err = StartWebListener(backend, eventMgr, "127.0.0.1:0", WebListenerOptions{Logger: logger})
+	if err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	defer StopWebListener()
+
+	addr := WebListenerAddr()
+	url := fmt.Sprintf("http://%s/api/systems", addr.String())
+	resp, err := http.Get(url) //nolint:noctx
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	found := false
+	for _, entry := range logs.All() {
+		if entry.Message == "http request" {
+			found = true
+			if entry.Level != zapcore.InfoLevel {
+				t.Errorf("expected INFO level, got %v", entry.Level)
+			}
+			ctx := entry.ContextMap()
+			if ctx["method"] != "GET" {
+				t.Errorf("expected method=GET, got %v", ctx["method"])
+			}
+			if ctx["path"] != "/api/systems" {
+				t.Errorf("expected path=/api/systems, got %v", ctx["path"])
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("no 'http request' log entry found")
+	}
+}
+
+func TestRequestLogging_NilLoggerDoesNotPanic(t *testing.T) {
+	sink := events.NewDummySink()
+	backend, err := model.NewModel(sink)
+	if err != nil {
+		t.Fatalf("failed to create model: %v", err)
+	}
+	eventMgr, err := eventmgr.NewEventManager()
+	if err != nil {
+		t.Fatalf("failed to create event manager: %v", err)
+	}
+
+	err = StartWebListener(backend, eventMgr, "127.0.0.1:0", WebListenerOptions{})
+	if err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	defer StopWebListener()
+
+	addr := WebListenerAddr()
+	url := fmt.Sprintf("http://%s/api/systems", addr.String())
+	resp, err := http.Get(url) //nolint:noctx
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	_ = resp.Body.Close()
+}
+
+func TestRequestLogging_SwaggerLogsAtDebug(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core).Sugar()
+
+	sink := events.NewDummySink()
+	backend, err := model.NewModel(sink)
+	if err != nil {
+		t.Fatalf("failed to create model: %v", err)
+	}
+	eventMgr, err := eventmgr.NewEventManager()
+	if err != nil {
+		t.Fatalf("failed to create event manager: %v", err)
+	}
+
+	err = StartWebListener(backend, eventMgr, "127.0.0.1:0", WebListenerOptions{Logger: logger})
+	if err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	defer StopWebListener()
+
+	addr := WebListenerAddr()
+	url := fmt.Sprintf("http://%s/swagger/index.html", addr.String())
+	resp, err := http.Get(url) //nolint:noctx
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	for _, entry := range logs.All() {
+		if entry.Message == "http request" {
+			if entry.Level != zapcore.DebugLevel {
+				t.Errorf("expected DEBUG for /swagger, got %v", entry.Level)
+			}
+			return
+		}
+	}
+	t.Error("no 'http request' log entry found for /swagger")
 }


### PR DESCRIPTION
Log every HTTP request with method, path, status code, and duration. API requests at INFO, 5xx at WARN, /metrics and /swagger at DEBUG. Both NewHandler and StartWebListener include the middleware.

Tests verify: API calls emit INFO with structured fields, nil logger does not panic, swagger paths emit DEBUG.

Depends on #167.
Closes #160