### PR TITLE
Add --log-level and --log-encoding CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ Supported URI schemes: `file://`, `http://` / `https://`, `s3://`. Local Sources
 S3 auth uses the default AWS credential chain (env, shared config, IAM role). File/object deletes
 do **not** remove landscape resources in v1.
 
+### Logging
+
+The server logs HTTP requests (method, path, status, duration) and lifecycle events using
+structured zap fields. API requests log at INFO; 5xx responses at WARN. Infrastructure
+paths (`/metrics`, `/swagger`) log at DEBUG.
+
+| Flag | Env | Default | Purpose |
+|------|-----|---------|---------| 
+| `--log-level` | `LOG_LEVEL` | *(debug)* | Log threshold: debug, info, warn, error |
+| `--log-encoding` | `LOG_ENCODING` | `console` | Log format: console or json |
+
+Library callers embedding modelsrv via `endpoint.NewHandler` or `endpoint.StartWebListener`
+pass their own logger through `WebListenerOptions.Logger`. When nil, no log output is emitted.
+
 ### OpenTelemetry Collector integration
 
 Keep an OpenTelemetry Collector

--- a/cmd/modelsrv/server.go
+++ b/cmd/modelsrv/server.go
@@ -27,6 +27,8 @@ const otelConfigShutdownTimeout = 30 * time.Second
 var serviceAddr string
 var dataDir string
 var sensorConfig string
+var logLevel string
+var logEncoding string
 var metricsAddr string
 var trustAuthHeaders bool
 var auditorIdentity string
@@ -55,6 +57,21 @@ func runServer(cmd *cobra.Command, _ []string) error {
 
 	cfg := zap.NewDevelopmentConfig()
 	cfg.DisableStacktrace = true
+	if logLevel != "" {
+		var level zap.AtomicLevel
+		if err := level.UnmarshalText([]byte(logLevel)); err != nil {
+			return fmt.Errorf("invalid log level %q: %w", logLevel, err)
+		}
+		cfg.Level = level
+	}
+	switch logEncoding {
+	case "", "console":
+		cfg.Encoding = "console"
+	case "json":
+		cfg.Encoding = "json"
+	default:
+		return fmt.Errorf("invalid log encoding %q: must be console or json", logEncoding)
+	}
 	log, err := cfg.Build()
 	if err != nil {
 		return fmt.Errorf("logger: %w", err)
@@ -195,6 +212,8 @@ func init() {
 	serverCmd.Flags().StringVarP(&serviceAddr, "service-addr", "a", envOrDefault("SERVICE_ADDR", ":8080"), "The address the service listens on")
 	serverCmd.Flags().StringVar(&dataDir, "data-dir", envOrDefault("DATA_DIR", "data"), "Directory to watch for landscape documents (.yaml/.yml/.json/.csv); relative paths are resolved from the process working directory")
 	serverCmd.Flags().StringVar(&sensorConfig, "sensor-config", envOrDefault("SENSOR_CONFIG", ""), "Optional YAML file listing Sources (file://, https://, s3://) and per-glob parser options; when set, overrides --data-dir")
+	serverCmd.Flags().StringVar(&logLevel, "log-level", envOrDefault("LOG_LEVEL", ""), "Log level: debug, info, warn, error (default: debug in dev mode)")
+	serverCmd.Flags().StringVar(&logEncoding, "log-encoding", envOrDefault("LOG_ENCODING", ""), "Log encoding: console, json (default: console)")
 	serverCmd.Flags().StringVar(&metricsAddr, "metrics-addr", envOrDefault("METRICS_ADDR", ""), "If set, serve /metrics on a separate port (e.g. :9090); otherwise metrics are on the main port")
 	serverCmd.Flags().BoolVar(&trustAuthHeaders, "trust-auth-headers", envOrDefault("TRUST_AUTH_HEADERS", "") == "true", "Trust X-Auth-* identity headers from the BFF and enforce ownership visibility")
 	serverCmd.Flags().StringVar(&auditorIdentity, "auditor-identity", envOrDefault("AUDITOR_IDENTITY", ""), "OIDC subject treated as auditor when matching X-Auth-Subject")

--- a/cmd/modelsrv/server_test.go
+++ b/cmd/modelsrv/server_test.go
@@ -64,6 +64,56 @@ func executeServer(t *testing.T, args ...string) error {
 	rootCmd.SetArgs(append([]string{"server"}, args...))
 	rootCmd.SetOut(io.Discard)
 	rootCmd.SetErr(io.Discard)
-	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		logLevel = ""
+		logEncoding = ""
+	})
 	return rootCmd.Execute()
+}
+
+func TestServerCmd_InvalidLogLevelReturnsError(t *testing.T) {
+	err := executeServer(t, "--log-level", "nope")
+	if err == nil {
+		t.Fatal("expected error for invalid log level")
+	}
+	if !strings.Contains(err.Error(), "invalid log level") {
+		t.Fatalf("error %q does not mention invalid log level", err)
+	}
+}
+
+func TestServerCmd_InvalidLogEncodingReturnsError(t *testing.T) {
+	err := executeServer(t, "--log-encoding", "xml")
+	if err == nil {
+		t.Fatal("expected error for invalid log encoding")
+	}
+	if !strings.Contains(err.Error(), "invalid log encoding") {
+		t.Fatalf("error %q does not mention invalid log encoding", err)
+	}
+}
+
+func TestServerCmd_LogEncodingJsonAccepted(t *testing.T) {
+	// json encoding with an invalid sensor-config to force early exit after logger setup
+	path := filepath.Join(t.TempDir(), "missing.yaml")
+	err := executeServer(t, "--log-encoding", "json", "--sensor-config", path)
+	if err == nil {
+		t.Fatal("expected error (missing sensor config)")
+	}
+	// The error should be about sensor config, not about encoding
+	if strings.Contains(err.Error(), "log encoding") {
+		t.Fatalf("unexpected encoding error: %v", err)
+	}
+}
+
+func TestServerCmd_LogLevelErrorSuppressesInfo(t *testing.T) {
+	// error level with an invalid sensor-config to force early exit
+	path := filepath.Join(t.TempDir(), "missing.yaml")
+	err := executeServer(t, "--log-level", "error", "--sensor-config", path)
+	if err == nil {
+		t.Fatal("expected error (missing sensor config)")
+	}
+	// The error should be about sensor config, not about log level
+	if strings.Contains(err.Error(), "log level") {
+		t.Fatalf("unexpected log level error: %v", err)
+	}
 }

--- a/pkg/endpoint/web_endpoint_test.go
+++ b/pkg/endpoint/web_endpoint_test.go
@@ -113,6 +113,9 @@ func TestRequestLogging_APICallEmitsInfoLog(t *testing.T) {
 	defer StopWebListener()
 
 	addr := WebListenerAddr()
+	if addr == nil {
+		t.Fatal("expected non-nil listener address")
+	}
 	url := fmt.Sprintf("http://%s/api/systems", addr.String())
 	resp, err := http.Get(url) //nolint:noctx
 	if err != nil {
@@ -160,6 +163,9 @@ func TestRequestLogging_NilLoggerDoesNotPanic(t *testing.T) {
 	defer StopWebListener()
 
 	addr := WebListenerAddr()
+	if addr == nil {
+		t.Fatal("expected non-nil listener address")
+	}
 	url := fmt.Sprintf("http://%s/api/systems", addr.String())
 	resp, err := http.Get(url) //nolint:noctx
 	if err != nil {
@@ -189,6 +195,9 @@ func TestRequestLogging_SwaggerLogsAtDebug(t *testing.T) {
 	defer StopWebListener()
 
 	addr := WebListenerAddr()
+	if addr == nil {
+		t.Fatal("expected non-nil listener address")
+	}
 	url := fmt.Sprintf("http://%s/swagger/index.html", addr.String())
 	resp, err := http.Get(url) //nolint:noctx
 	if err != nil {


### PR DESCRIPTION
Configurable log level (debug/info/warn/error) via --log-level / LOG_LEVEL. Configurable encoding (console/json) via --log-encoding / LOG_ENCODING. Invalid values fail startup with a clear error message.

Document both flags in the README logging section.

Depends on #168.
Closes #161